### PR TITLE
fix: sandbox path and task auto-schedule

### DIFF
--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -17,7 +17,7 @@ async function setupDirectories() {
       let candidates;
       if (os.platform() === 'darwin') {
         candidates = [
-          path.join(home, 'Library', 'Containers', 'com.superproductivity.app', 'Data', 'Library', 'Application Support', APP),
+          path.join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP),
           path.join(home, 'Library', 'Application Support', APP)
         ];
       } else if (os.platform() === 'win32') {

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -10,7 +10,7 @@ function getCandidatePaths(): string[] {
   switch (platform()) {
     case 'darwin':
       return [
-        join(home, 'Library', 'Containers', 'com.superproductivity.app', 'Data', 'Library', 'Application Support', APP_NAME),
+        join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP_NAME),
         join(home, 'Library', 'Application Support', APP_NAME),
       ];
     case 'win32':

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -46,6 +46,15 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (project_id) data.projectId = project_id;
       if (parent_id) data.parentId = parent_id;
 
+      // SP auto-assigns plannedAt/dueDay to today when viewing Today context.
+      // Passing null satisfies SP's `'dueDay' in additional` guard, preventing auto-scheduling
+      // unless the title contains @date syntax (which SP will parse into a date itself).
+      const hasDateSyntax = /@/.test(title);
+      if (!hasDateSyntax) {
+        data.plannedAt = null;
+        data.dueDay = null;
+      }
+
       // T016: subtask SP syntax workaround
       const hasSyntax = parent_id && /[@#[+]]/.test(title);
       if (hasSyntax) {


### PR DESCRIPTION
## Summary
- Correct Mac App Store bundle ID in sandbox path
- Prevent `create_task` from auto-scheduling tasks to Today

## Test plan
- [ ] Verify plugin loads correctly under Mac App Store sandbox
- [ ] Verify `create_task` does not set a date unless explicitly provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)