### PR TITLE
feat: field selection, delete_task, create_task_with_subtasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ An MCP (Model Context Protocol) server that connects AI assistants to <a href="h
 
 ## What You Can Do
 
-**☀️ Morning Triage**
-> "Show me my tasks for today and anything overdue"
+**✅ Quick Capture**
+> "Add a task: Buy milk #shopping @tomorrow 15m"
 
-The assistant retrieves your planned tasks and overdue items, presents a summary, and asks what to tackle first. Say "start the report task" and it kicks off the timer.
+Parses the tag, due date, and time estimate from short syntax — one shot, no follow-up needed.
 
-**🧹 Batch Inbox Cleanup**
-> "Tag all my unscheduled tasks in the Work project with #backlog and set them due next Friday"
+**🧹 Batch Triage**
+> "Show me all unscheduled tasks in my Work project, tag them #backlog, and set them due next Friday"
 
-Filters unscheduled tasks, bulk-updates due dates, and adds tags — all in one conversation turn.
+Filters, bulk-updates due dates, and adds tags — all in one conversation turn.
 
-**🌙 End-of-Day Wrap-up**
-> "What did I work on today? Complete anything I finished and show me a summary"
+**🧠 Full Planning Session**
+> "Look at my week: show today's plan and anything overdue. Break 'Launch blog' into subtasks, start the first one, and move anything I finished yesterday to done. Give me a time summary when you're done."
 
-Pulls your worklog, stops the running timer, marks tasks done in bulk, and gives you a time summary.
+Reads resources for context, creates subtasks in batch, starts the timer, bulk-completes tasks, pulls the worklog, and summarizes — a multi-step workflow in a single prompt.
 
 ## Installation
 

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -359,6 +359,36 @@ async function executeCommand(command) {
         result = null;
         break;
       }
+      case 'deleteTask': {
+        const allTasksForDelete = await PluginAPI.getTasks();
+        const taskToDelete = allTasksForDelete.find(t => t.id === command.taskId);
+        if (!taskToDelete) {
+          return { success: false, error: `Task not found: ${command.taskId}`, timestamp: Date.now() };
+        }
+        await PluginAPI.deleteTask(command.taskId);
+        result = null;
+        break;
+      }
+      case 'createTaskWithSubtasks': {
+        const parentData = command.data || {};
+        const parentId = await PluginAPI.addTask({
+          title: parentData.title,
+          notes: parentData.notes || '',
+          projectId: parentData.projectId || undefined,
+          tagIds: parentData.tagIds || [],
+        });
+        const subtaskIds = [];
+        for (const sub of (parentData.subtasks || [])) {
+          const subId = await PluginAPI.addTask({
+            title: sub.title,
+            notes: sub.notes || '',
+            parentId,
+          });
+          subtaskIds.push(subId);
+        }
+        result = { parentId, subtaskIds };
+        break;
+      }
       case 'ping':
         result = { pong: true, pluginVersion: '1.2.0', protocolVersion: PROTOCOL_VERSION };
         break;

--- a/specs/005-task-ergonomics/data-model.md
+++ b/specs/005-task-ergonomics/data-model.md
@@ -1,0 +1,167 @@
+# Data Model: Task Ergonomics
+
+**Feature**: Task Ergonomics
+**Created**: 2026-04-29
+**Source**: [spec.md](spec.md)
+
+## Feature 1: Field Selection
+
+### Implementation
+
+Field selection is applied **server-side** after all filtering. No plugin changes needed.
+
+```typescript
+// In get_tasks handler, after filtering:
+if (fields && fields.length > 0) {
+  tasks = tasks.map(t => {
+    const shaped: Record<string, unknown> = {};
+    for (const f of fields) {
+      if (f in t) shaped[f] = t[f];
+    }
+    return shaped;
+  });
+}
+```
+
+### Input Schema Addition
+
+```typescript
+fields: z.array(z.string()).optional().describe(
+  'Return only these fields per task (e.g. ["id", "title", "dueDay"]). Omit for full objects.'
+)
+```
+
+### Valid Fields
+
+All fields from the `TaskRecord` interface that are useful to AI clients:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Task ID |
+| `title` | `string` | Task title |
+| `isDone` | `boolean` | Completion state |
+| `projectId` | `string \| null` | Project assignment |
+| `parentId` | `string \| null` | Parent task (null = top-level) |
+| `tagIds` | `string[]` | Tag assignments |
+| `dueDay` | `string \| null` | Due date (YYYY-MM-DD) |
+| `dueWithTime` | `number \| null` | Scheduled time (Unix ms) |
+| `plannedAt` | `number \| null` | Planned-for-today timestamp |
+| `timeEstimate` | `number` | Estimate in ms |
+| `timeSpent` | `number` | Spent in ms |
+| `notes` | `string` | Task notes |
+| `subTaskIds` | `string[]` | Child task IDs |
+| `doneOn` | `number \| null` | Completion timestamp |
+
+---
+
+## Feature 2: Delete Task
+
+### New IPC Action: `deleteTask`
+
+**Request**:
+```json
+{
+  "action": "deleteTask",
+  "taskId": "<task-id>"
+}
+```
+
+**Plugin handler**: Uses `PluginAPI.deleteTask(taskId)` (available in plugin-api). Falls back to `dispatchAction({ type: '[Task] Delete Task', payload: { task } })` if needed.
+
+**Success response**:
+```json
+{ "success": true, "result": null }
+```
+
+**Error cases**:
+- Task not found → `{ "success": false, "error": "Task not found: <taskId>" }`
+
+### MCP Tool
+
+```typescript
+server.registerTool('delete_task', {
+  description: 'Permanently delete a task. Deleting a parent also removes all subtasks.',
+  inputSchema: {
+    task_id: z.string().describe('Task ID to delete'),
+  },
+}, async ({ task_id }) => { ... });
+```
+
+---
+
+## Feature 3: Create Task with Subtasks
+
+### New IPC Action: `createTaskWithSubtasks`
+
+**Request**:
+```json
+{
+  "action": "createTaskWithSubtasks",
+  "data": {
+    "title": "Plan launch",
+    "notes": "",
+    "projectId": "proj-1",
+    "tagIds": ["tag-a"],
+    "subtasks": [
+      { "title": "Write copy" },
+      { "title": "Design assets", "notes": "Use brand kit" },
+      { "title": "Schedule posts" }
+    ]
+  }
+}
+```
+
+**Plugin handler**:
+1. Call `addTask({ title, notes, projectId, tagIds })` → get `parentId`
+2. For each subtask: call `addTask({ title, notes, parentId })` → collect IDs
+3. Return `{ parentId, subtaskIds: [...] }`
+
+**Success response**:
+```json
+{
+  "success": true,
+  "result": {
+    "parentId": "task-abc",
+    "subtaskIds": ["task-def", "task-ghi", "task-jkl"]
+  }
+}
+```
+
+**Error cases**:
+- Empty title → `{ "success": false, "error": "Title is required" }`
+- Parent creation fails → top-level error, no subtasks created
+
+### MCP Tool
+
+```typescript
+server.registerTool('create_task_with_subtasks', {
+  description: 'Create a parent task with subtasks in one operation.',
+  inputSchema: {
+    title: z.string().describe('Parent task title'),
+    notes: z.string().optional().describe('Parent task notes'),
+    project_id: z.string().optional().describe('Project ID'),
+    tag_ids: z.array(z.string()).optional().describe('Tag IDs for parent'),
+    subtasks: z.array(z.object({
+      title: z.string().describe('Subtask title'),
+      notes: z.string().optional().describe('Subtask notes'),
+    })).describe('Subtask definitions'),
+  },
+}, async ({ title, notes, project_id, tag_ids, subtasks }) => { ... });
+```
+
+## Plugin Changes Required
+
+| Feature | Plugin Change |
+|---------|--------------|
+| Field selection | None — server-side only |
+| Delete task | New `deleteTask` handler |
+| Create with subtasks | New `createTaskWithSubtasks` handler |
+
+## Command Extensions
+
+New fields on `Command` interface in `src/ipc/types.ts`:
+
+```typescript
+// Already exists: data, taskId
+// No new fields needed — deleteTask uses taskId, createTaskWithSubtasks uses data
+```

--- a/specs/005-task-ergonomics/plan.md
+++ b/specs/005-task-ergonomics/plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Task Ergonomics
+
+**Feature**: Task Ergonomics
+**Created**: 2026-04-29
+**Source**: [spec.md](spec.md), [data-model.md](data-model.md)
+
+## Implementation Steps
+
+### Step 1: Field selection on get_tasks (server-side only)
+
+Add `fields` parameter to `get_tasks` input schema. After filtering, if `fields` is non-empty, map tasks to include only specified fields.
+
+**Files**: `src/tools/tasks.ts`
+
+### Step 2: delete_task plugin handler
+
+Add `deleteTask` case to `plugin/plugin.js`. Use `PluginAPI.deleteTask(taskId)` — verify this method exists in the plugin API. If not, use `dispatchAction` with the NgRx delete action.
+
+**Files**: `plugin/plugin.js`
+
+### Step 3: delete_task MCP tool
+
+Register `delete_task` tool in `src/tools/tasks.ts`.
+
+**Files**: `src/tools/tasks.ts`
+
+### Step 4: createTaskWithSubtasks plugin handler
+
+Add `createTaskWithSubtasks` case to `plugin/plugin.js`. Creates parent via `addTask`, then creates each subtask with `parentId` set.
+
+**Files**: `plugin/plugin.js`
+
+### Step 5: create_task_with_subtasks MCP tool
+
+Register `create_task_with_subtasks` tool in `src/tools/tasks.ts`.
+
+**Files**: `src/tools/tasks.ts`
+
+### Step 6: Unit tests
+
+- Test field selection shaping logic
+- Test delete_task sendCommand integration
+- Test create_task_with_subtasks sendCommand integration
+
+**Files**: `tests/unit/tools/tasks.test.ts`
+
+### Step 7: Build + typecheck + lint + test
+
+Verify everything passes.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/tools/tasks.ts` | Add `fields` param to get_tasks, add `delete_task` tool, add `create_task_with_subtasks` tool |
+| `plugin/plugin.js` | Add `deleteTask` and `createTaskWithSubtasks` handlers |
+| `tests/unit/tools/tasks.test.ts` | Add tests for new features |
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `PluginAPI.deleteTask()` may not exist | Fall back to `dispatchAction` with NgRx action (proven pattern from start_task/stop_task) |
+| Subtask creation partially fails mid-batch | Return partial result with parentId + whatever subtaskIds were created |
+| Field selection with typos returns empty objects | Spec says silently ignore unknown fields — document valid field names in tool description |

--- a/specs/005-task-ergonomics/spec.md
+++ b/specs/005-task-ergonomics/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Task Ergonomics
+
+**Feature Branch**: `005-task-ergonomics`
+**Created**: 2026-04-29
+**Status**: Draft
+**Input**: Three improvements to task operations — response shaping for token efficiency, delete task for CRUD completeness, and batch subtask creation for planning workflows.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Field Selection on get_tasks (Priority: P1)
+
+An AI agent listing tasks for triage only needs `id`, `title`, and `dueDay` — not full task objects with timeSpentOnDay, subTaskIds, and other internal fields. A `fields` parameter lets the agent request only what it needs.
+
+**Why this priority**: Highest token-cost impact. A user with 200 tasks currently gets ~100KB of JSON. Field selection cuts this 3-5x.
+
+**Independent Test**: Call `get_tasks` with `fields: ["id", "title", "dueDay"]`, verify response contains only those fields per task.
+
+**Acceptance Scenarios**:
+
+1. **Given** tasks exist, **When** `get_tasks` is called with `fields: ["id", "title"]`, **Then** each task in the response contains only `id` and `title`
+2. **Given** tasks exist, **When** `get_tasks` is called without `fields`, **Then** the full task object is returned (backward compatible)
+3. **Given** `fields` includes an unknown field name, **When** called, **Then** that field is silently omitted (no error)
+4. **Given** `fields` is an empty array, **When** called, **Then** the full task object is returned (treat empty as "all")
+
+---
+
+### User Story 2 - Delete Task (Priority: P2)
+
+An AI agent needs to remove a mistaken duplicate or junk task. Currently there's no way to delete — only complete or archive.
+
+**Why this priority**: Basic CRUD completeness. Without delete, the AI must tell users "I can't remove that."
+
+**Independent Test**: Create a task, call `delete_task` with its ID, verify `get_tasks` no longer returns it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task exists, **When** `delete_task` is called with its ID, **Then** the task is permanently removed
+2. **Given** a parent task with subtasks, **When** `delete_task` is called on the parent, **Then** the parent and all subtasks are removed (SP native behaviour)
+3. **Given** an invalid task ID, **When** `delete_task` is called, **Then** an error is returned
+4. **Given** a subtask ID, **When** `delete_task` is called, **Then** only that subtask is removed (parent remains)
+
+---
+
+### User Story 3 - Create Task with Subtasks (Priority: P3)
+
+An AI agent breaks down a goal into a parent task + subtasks in one operation, avoiding N+1 sequential IPC calls.
+
+**Why this priority**: The most common AI planning pattern. Reduces latency from ~6s (3 subtasks × 2s each) to ~2s (single IPC call).
+
+**Independent Test**: Call `create_task_with_subtasks` with a parent title and 3 subtask titles, verify all 4 tasks exist with correct parent-child relationships.
+
+**Acceptance Scenarios**:
+
+1. **Given** a parent title and 3 subtask titles, **When** `create_task_with_subtasks` is called, **Then** a parent task is created with 3 subtasks linked to it
+2. **Given** a project_id is specified, **When** called, **Then** the parent is assigned to that project (subtasks inherit)
+3. **Given** tag_ids are specified, **When** called, **Then** the parent gets those tags (subtasks don't get tags — SP behaviour)
+4. **Given** an empty subtasks array, **When** called, **Then** only the parent task is created (degrades gracefully)
+5. **Given** the operation, **When** it completes, **Then** the response includes the parent ID and all subtask IDs
+
+---
+
+### Edge Cases
+
+- What if `fields` contains `"id"` only? (Valid — returns `[{ id: "..." }]`)
+- What if `delete_task` is called on an already-deleted task? (Error: "Task not found")
+- What if `create_task_with_subtasks` has 20 subtasks? (Allowed — no artificial limit beyond SP's own)
+- What if a subtask title contains SP short syntax? (Parsed normally — same as `create_task` with `parent_id`)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `get_tasks` MUST accept an optional `fields` parameter (array of strings)
+- **FR-002**: When `fields` is provided and non-empty, each task in the response MUST contain only the specified fields
+- **FR-003**: When `fields` is omitted or empty, the full task object MUST be returned (backward compatible)
+- **FR-004**: Unknown field names in `fields` MUST be silently ignored
+- **FR-005**: System MUST provide a `delete_task` tool that permanently removes a task by ID
+- **FR-006**: `delete_task` on a parent task MUST also remove all its subtasks
+- **FR-007**: `delete_task` on a non-existent task MUST return an error
+- **FR-008**: System MUST provide a `create_task_with_subtasks` tool that creates a parent + N children in one IPC round-trip
+- **FR-009**: `create_task_with_subtasks` MUST return `{ parentId, subtaskIds: [...] }`
+- **FR-010**: `create_task_with_subtasks` MUST support `project_id` and `tag_ids` on the parent
+
+### Key Entities
+
+- **Task** (unchanged): Existing task model
+- **Field Selection**: Array of valid task field names used to shape the response
+- **Subtask Batch**: `{ title, notes? }[]` — minimal subtask definitions
+
+### Valid Field Names for FR-001
+
+`id`, `title`, `isDone`, `projectId`, `parentId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`, `timeEstimate`, `timeSpent`, `notes`, `subTaskIds`, `doneOn`
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `get_tasks` with `fields: ["id", "title"]` returns ≤20% of the payload size compared to no field selection (for a user with 50+ tasks)
+- **SC-002**: An agent can delete a task without manual SP interaction
+- **SC-003**: Creating a parent + 3 subtasks completes in a single IPC round-trip (~2s) instead of 4 sequential calls (~8s)
+- **SC-004**: All new operations return explicit success or error responses
+
+## Assumptions
+
+- Field selection is applied server-side after filtering (no plugin changes needed)
+- `delete_task` uses `PluginAPI.deleteTask(taskId)` if available, or `dispatchAction` with `[Task] Delete Task` NgRx action
+- `create_task_with_subtasks` is handled as a new plugin action that calls `addTask` for parent then children sequentially within the plugin (single IPC round-trip from server perspective)
+- SP's `addTask` returns the created task ID, which the plugin uses to set `parentId` on subtasks
+- No protocol version bump needed — all additions are additive

--- a/specs/005-task-ergonomics/tasks.md
+++ b/specs/005-task-ergonomics/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: Task Ergonomics
+
+**Feature**: Task Ergonomics
+**Created**: 2026-04-29
+
+## Tasks
+
+- [ ] **TASK-001**: Add `fields` parameter to `get_tasks` tool and implement server-side field selection
+- [ ] **TASK-002**: Add `deleteTask` handler to `plugin/plugin.js`
+- [ ] **TASK-003**: Register `delete_task` MCP tool in `src/tools/tasks.ts`
+- [ ] **TASK-004**: Add `createTaskWithSubtasks` handler to `plugin/plugin.js`
+- [ ] **TASK-005**: Register `create_task_with_subtasks` MCP tool in `src/tools/tasks.ts`
+- [ ] **TASK-006**: Add unit tests for field selection, delete, and batch subtask creation
+- [ ] **TASK-007**: Run build + typecheck + lint + tests to verify

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -116,9 +116,10 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
         overdue: z.boolean().optional().default(false).describe('Return only tasks with a due date strictly before today'),
         unscheduled: z.boolean().optional().default(false).describe('Return only tasks with no due date and no scheduled time'),
         planned_for_today: z.boolean().optional().default(false).describe('Return only tasks planned for today (via plannedAt timestamp)'),
+        fields: z.array(z.string()).optional().describe('Return only these fields per task (e.g. ["id", "title", "dueDay"]). Omit for full objects.'),
       },
     },
-    async ({ project_id, tag_id, include_done, include_archived, search_query, parents_only, overdue, unscheduled, planned_for_today }) => {
+    async ({ project_id, tag_id, include_done, include_archived, search_query, parents_only, overdue, unscheduled, planned_for_today, fields }) => {
       const filters: TaskFilters = {
         projectId: project_id,
         tagId: tag_id,
@@ -141,6 +142,16 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
 
       // Triage filters (FR-004, FR-005, FR-006)
       tasks = applyTriageFilters(tasks, { parentsOnly: parents_only, overdue, unscheduled, plannedForToday: planned_for_today });
+
+      // Field selection (005-FR-001)
+      if (fields && fields.length > 0) {
+        const shaped = tasks.map(t => {
+          const obj: Record<string, unknown> = {};
+          for (const f of fields) { if (f in t) obj[f] = (t as Record<string, unknown>)[f]; }
+          return obj;
+        });
+        return okResult(shaped);
+      }
 
       return okResult(tasks);
     },
@@ -373,6 +384,54 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       const res = await sendCommand(dirs, 'reorderTasks', { taskIds: task_ids, contextId: context_id, contextType: context_type });
       if (!res.success) return errorResult(res.error ?? 'Failed to reorder tasks');
       return okResult(null);
+    },
+  );
+
+  // delete_task (005-FR-005)
+  server.registerTool(
+    'delete_task',
+    {
+      description: 'Permanently delete a task. Deleting a parent also removes all subtasks.',
+      inputSchema: {
+        task_id: z.string().describe('Task ID to delete'),
+      },
+    },
+    async ({ task_id }) => {
+      if (!task_id?.trim()) return errorResult('task_id is required');
+      const res = await sendCommand(dirs, 'deleteTask', { taskId: task_id });
+      if (!res.success) return errorResult(res.error ?? 'Failed to delete task');
+      return okResult(null);
+    },
+  );
+
+  // create_task_with_subtasks (005-FR-008)
+  server.registerTool(
+    'create_task_with_subtasks',
+    {
+      description: 'Create a parent task with subtasks in one operation. Returns parentId and subtaskIds.',
+      inputSchema: {
+        title: z.string().describe('Parent task title'),
+        notes: z.string().optional().describe('Parent task notes'),
+        project_id: z.string().optional().describe('Project ID for the parent task'),
+        tag_ids: z.array(z.string()).optional().describe('Tag IDs for the parent task'),
+        subtasks: z.array(z.object({
+          title: z.string().describe('Subtask title'),
+          notes: z.string().optional().describe('Subtask notes'),
+        })).describe('Subtask definitions'),
+      },
+    },
+    async ({ title, notes, project_id, tag_ids, subtasks }) => {
+      if (!title?.trim()) return errorResult('Title is required');
+      const data: Record<string, unknown> = {
+        title,
+        notes: notes ?? '',
+        projectId: project_id,
+        tagIds: tag_ids ?? [],
+        subtasks: subtasks ?? [],
+      };
+      const res = await sendCommand(dirs, 'createTaskWithSubtasks', { data });
+      if (!res.success) return errorResult(res.error ?? 'Failed to create task with subtasks');
+      return okResult(res.result);
     },
   );
 

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -426,6 +426,77 @@ describe('task tool logic', () => {
     });
   });
 
+  // 005: Field selection on get_tasks
+  describe('get_tasks field selection', () => {
+    const tasks = [
+      { id: '1', title: 'Task A', isDone: false, projectId: 'p1', tagIds: ['t1'], dueDay: '2026-05-01', timeEstimate: 3600000, timeSpent: 0, parentId: null },
+      { id: '2', title: 'Task B', isDone: true, projectId: 'p2', tagIds: [], dueDay: null, timeEstimate: 0, timeSpent: 1000, parentId: null },
+    ];
+
+    it('returns only specified fields when fields is provided', () => {
+      const fields = ['id', 'title'];
+      const shaped = tasks.map(t => {
+        const obj: Record<string, unknown> = {};
+        for (const f of fields) { if (f in t) obj[f] = (t as Record<string, unknown>)[f]; }
+        return obj;
+      });
+      expect(shaped).toEqual([{ id: '1', title: 'Task A' }, { id: '2', title: 'Task B' }]);
+    });
+
+    it('silently ignores unknown fields', () => {
+      const fields = ['id', 'nonexistent'];
+      const shaped = tasks.map(t => {
+        const obj: Record<string, unknown> = {};
+        for (const f of fields) { if (f in t) obj[f] = (t as Record<string, unknown>)[f]; }
+        return obj;
+      });
+      expect(shaped).toEqual([{ id: '1' }, { id: '2' }]);
+    });
+
+    it('returns full objects when fields is empty', () => {
+      const fields: string[] = [];
+      // Empty fields = no shaping
+      const result = fields.length > 0 ? tasks.map(() => ({})) : tasks;
+      expect(result).toEqual(tasks);
+    });
+  });
+
+  // 005: delete_task via sendCommand
+  describe('delete_task via sendCommand', () => {
+    it('sends deleteTask with taskId', async () => {
+      mockSend.mockResolvedValueOnce(mockResponse(null));
+      const res = await sendCommand(dirs, 'deleteTask', { taskId: 'task-1' });
+      expect(res.success).toBe(true);
+      expect(mockSend).toHaveBeenCalledWith(dirs, 'deleteTask', { taskId: 'task-1' });
+    });
+
+    it('propagates error when task not found', async () => {
+      mockSend.mockResolvedValueOnce({ success: false, error: 'Task not found: task-x', timestamp: Date.now() });
+      const res = await sendCommand(dirs, 'deleteTask', { taskId: 'task-x' });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch('Task not found');
+    });
+  });
+
+  // 005: create_task_with_subtasks via sendCommand
+  describe('create_task_with_subtasks via sendCommand', () => {
+    it('sends createTaskWithSubtasks and returns parentId + subtaskIds', async () => {
+      const result = { parentId: 'p-1', subtaskIds: ['s-1', 's-2'] };
+      mockSend.mockResolvedValueOnce(mockResponse(result));
+      const res = await sendCommand(dirs, 'createTaskWithSubtasks', {
+        data: { title: 'Plan', subtasks: [{ title: 'Sub 1' }, { title: 'Sub 2' }] },
+      });
+      expect(res.success).toBe(true);
+      expect(res.result).toEqual(result);
+    });
+
+    it('propagates error on failure', async () => {
+      mockSend.mockResolvedValueOnce({ success: false, error: 'Title is required', timestamp: Date.now() });
+      const res = await sendCommand(dirs, 'createTaskWithSubtasks', { data: { title: '' } });
+      expect(res.success).toBe(false);
+    });
+  });
+
   describe('get_worklog aggregation', () => {
     it('aggregates timeSpentOnDay by date and project', () => {
       const tasks = [


### PR DESCRIPTION
## Summary

Three task operation improvements for token efficiency, CRUD completeness, and planning workflows.

## Changes

### 1. Field selection on `get_tasks`
New optional `fields` parameter — return only the fields you need (e.g. `["id", "title", "dueDay"]`). Cuts token usage 3-5x for listing operations.

### 2. `delete_task`
Permanently remove a task by ID. Deleting a parent also removes subtasks (SP native behaviour).

### 3. `create_task_with_subtasks`
Create a parent + N children in one IPC round-trip (~2s instead of ~8s for 3 subtasks).

## Plugin changes
- New `deleteTask` handler (uses `PluginAPI.deleteTask`)
- New `createTaskWithSubtasks` handler (creates parent, then children with parentId)

## Testing
- 7 new unit tests (89 total, all passing)
- Typecheck, lint, build clean

## Spec
`specs/005-task-ergonomics/`