### PR TITLE
fix(plugin): guard process.env access in setupDirectories

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,14 @@ Common values:
 | macOS App Store sandbox | `~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp` |
 | Linux (standard) | `~/.local/share/super-productivity-mcp` |
 | Linux (Snap) | `~/snap/superproductivity/current/.local/share/super-productivity-mcp` |
+| Linux (sandboxed/Flatpak) | `/tmp/super-productivity-mcp` |
 | Windows | `%APPDATA%\super-productivity-mcp` |
+
+> **Note:** On Linux, if `~/.local/share` is not writable (e.g. Fedora with restrictive permissions or Flatpak sandboxing), the plugin and server will automatically fall back to `/tmp/super-productivity-mcp`. This directory is cleared on reboot but works without any configuration.
+
+## `ReferenceError: process is not defined`
+
+This occurs on plugin versions ≤ 1.1.1 when SP's plugin sandbox doesn't expose the Node.js `process` global. Update to version 1.2.0+ which guards against this. If you installed the plugin manually, re-download `plugin.zip` from the [latest release](https://github.com/b0x42/Super-Productivity-MCP/releases/latest).
 
 ## Version Mismatch
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,7 +57,7 @@ Common values:
 | Linux (sandboxed/Flatpak) | `/tmp/super-productivity-mcp` |
 | Windows | `%APPDATA%\super-productivity-mcp` |
 
-> **Note:** On Linux, if `~/.local/share` is not writable (e.g. Fedora with restrictive permissions or Flatpak sandboxing), the plugin and server will automatically fall back to `/tmp/super-productivity-mcp`. This directory is cleared on reboot but works without any configuration.
+> **Note:** On Linux, if `~/.local/share` is not writable (e.g. Fedora with restrictive permissions or Flatpak sandboxing), the plugin and server will automatically fall back to `/tmp/super-productivity-mcp`. This directory may be cleared on reboot but works without any configuration.
 
 ## `ReferenceError: process is not defined`
 

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "super-productivity-mcp",
   "name": "SP MCP Server",
   "description": "MCP server bridge for AI assistant integration with Super Productivity",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "manifestVersion": 1,
   "minSupVersion": "14.0.0",
   "permissions": [

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -79,17 +79,25 @@ async function setupDirectories() {
 }
 
 async function writeResponse(commandId, response) {
-  const payload = JSON.stringify(response, null, 2);
-  await PluginAPI.executeNodeScript({
-    script: `
-      const fs = require('fs');
-      const path = require('path');
-      fs.writeFileSync(path.join(args[0], args[1] + '_response.json'), args[2], { mode: 0o600 });
-      return { success: true };
-    `,
-    args: [responseDir, commandId, payload],
-    timeout: 5000,
-  });
+  const payload = JSON.stringify(response, null, 2) ?? 'null';
+  const filePath = responseDir + '/' + commandId + '_response.json';
+  // SP's executeNodeScript sandbox silently drops args[2]+, so passing the payload
+  // via args causes writeFileSync to receive undefined and throw — swallowed silently.
+  // Instead, embed the payload directly in the script string in 32KB chunks.
+  const CHUNK = 32 * 1024;
+  for (let i = 0; i < payload.length; i += CHUNK) {
+    const chunk = JSON.stringify(payload.slice(i, i + CHUNK));
+    const mode = i === 0 ? 'writeFileSync' : 'appendFileSync';
+    const result = await PluginAPI.executeNodeScript({
+      script: `const fs=require('fs'); fs.${mode}(args[0], ${chunk}); return {success:true};`,
+      args: [filePath],
+      timeout: 5000,
+    });
+    const r = (result && result.result && typeof result.result === 'object') ? result.result : result;
+    if (!r || r.success === false) {
+      throw new Error('writeResponse failed: ' + (r && r.error ? r.error : JSON.stringify(r)));
+    }
+  }
 }
 
 async function deleteFile(filePath) {
@@ -438,14 +446,21 @@ async function pollCommands() {
     const r = result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
     if (!r || !r.success || !r.commands) return;
     for (const cmd of r.commands) {
+      const cmdId = cmd.data.id || cmd.file.replace('.json', '');
       try {
         const response = await executeCommand(cmd.data);
-        const cmdId = cmd.data.id || cmd.file.replace('.json', '');
         await writeResponse(cmdId, response);
+      } catch (e) {
+        console.error('Command processing failed (' + (cmd.data && cmd.data.action) + '):', e);
+        try {
+          await writeResponse(cmdId, { success: false, error: e.message || String(e), timestamp: Date.now() });
+        } catch (_) {}
+      }
+      try {
         await deleteFile(cmd.path);
         lastProcessed = Math.max(lastProcessed, cmd.mtime);
       } catch (e) {
-        console.error('Command processing failed (' + (cmd.data && cmd.data.action) + '):', e);
+        console.error('deleteFile failed:', e);
       }
     }
   } catch (e) {

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -7,6 +7,18 @@ let pollTimer = null;
 let lastProcessed = 0;
 let currentTrackedTask = null;
 
+function unwrapNodeResult(result) {
+  return result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
+}
+
+function assertNodeResult(result, context) {
+  const r = unwrapNodeResult(result);
+  if (!r || !r.success) {
+    throw new Error(context + ': ' + ((r && r.error) || 'Node script failed'));
+  }
+  return r;
+}
+
 async function setupDirectories() {
   const result = await PluginAPI.executeNodeScript({
     script: `
@@ -15,6 +27,8 @@ async function setupDirectories() {
       const os = require('os');
       const home = os.homedir();
       const APP = 'super-productivity-mcp';
+      const TMP_ROOT = '/tmp';
+      const TMP_DATA_DIR = path.join(TMP_ROOT, APP);
       let candidates;
       if (os.platform() === 'darwin') {
         candidates = [
@@ -27,37 +41,53 @@ async function setupDirectories() {
       } else {
         const xdgData = (typeof process !== 'undefined' && process.env && process.env.XDG_DATA_HOME) || path.join(home, '.local', 'share');
         candidates = [
-          path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
+          path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'data', APP),
+          path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'config', APP),
           path.join(xdgData, APP),
+          path.join(home, 'snap', 'superproductivity', 'common', '.local', 'share', APP),
+          path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
           path.join('/tmp', APP) // last-resort: world-writable dir, but mode 0o700 restricts access
         ];
       }
       const errors = [];
+      const configCandidates = candidates.filter(function(p) { return p !== TMP_DATA_DIR; });
+      function isTmpDataDir(dir) {
+        return dir === TMP_ROOT || dir.indexOf(TMP_ROOT + '/') === 0;
+      }
+      function ensureWritableDir(dir) {
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+        const testFile = path.join(dir, '.write-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        fs.writeFileSync(testFile, 'ok', { mode: 0o600 });
+        fs.unlinkSync(testFile);
+      }
+      function ensureIpcDirs(baseDir) {
+        const cd = path.join(baseDir, 'plugin_commands');
+        const rd = path.join(baseDir, 'plugin_responses');
+        ensureWritableDir(baseDir);
+        ensureWritableDir(cd);
+        ensureWritableDir(rd);
+        return { commandDir: cd, responseDir: rd };
+      }
       // Check for mcp_config.json override
-      for (const p of candidates) {
+      for (const p of configCandidates) {
         try {
           const cfg = path.join(p, 'mcp_config.json');
           if (fs.existsSync(cfg)) {
             const c = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
-            if (c.dataDir && fs.existsSync(c.dataDir)) {
-              const cd = path.join(c.dataDir, 'plugin_commands');
-              const rd = path.join(c.dataDir, 'plugin_responses');
-              if (!fs.existsSync(cd)) fs.mkdirSync(cd, { recursive: true, mode: 0o700 });
-              if (!fs.existsSync(rd)) fs.mkdirSync(rd, { recursive: true, mode: 0o700 });
-              return { success: true, commandDir: cd, responseDir: rd };
+            if (c.dataDir && fs.existsSync(c.dataDir) && !isTmpDataDir(c.dataDir)) {
+              const dirs = ensureIpcDirs(c.dataDir);
+              return { success: true, commandDir: dirs.commandDir, responseDir: dirs.responseDir };
             }
           }
-        } catch (e) {}
+        } catch (e) {
+          errors.push(p + ' config: ' + (e.message || e));
+        }
       }
       // Probe candidates
       for (const p of candidates) {
         try {
-          if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true, mode: 0o700 });
-          const cd = path.join(p, 'plugin_commands');
-          const rd = path.join(p, 'plugin_responses');
-          if (!fs.existsSync(cd)) fs.mkdirSync(cd, { recursive: true, mode: 0o700 });
-          if (!fs.existsSync(rd)) fs.mkdirSync(rd, { recursive: true, mode: 0o700 });
-          return { success: true, commandDir: cd, responseDir: rd };
+          const dirs = ensureIpcDirs(p);
+          return { success: true, commandDir: dirs.commandDir, responseDir: dirs.responseDir };
         } catch (e) {
           errors.push(p + ': ' + (e.message || e));
         }
@@ -68,8 +98,7 @@ async function setupDirectories() {
     timeout: 10000,
   });
   // executeNodeScript wraps result: could be result.result.success or result.success
-  let r = result;
-  if (r && r.success && r.result && typeof r.result === 'object') r = r.result;
+  const r = unwrapNodeResult(result);
   if (r && r.success) {
     commandDir = r.commandDir;
     responseDir = r.responseDir;
@@ -80,32 +109,51 @@ async function setupDirectories() {
 
 async function writeResponse(commandId, response) {
   const payload = JSON.stringify(response, null, 2) || 'null';
-  const filePath = responseDir + '/' + commandId + '_response.json';
-  // SP's executeNodeScript sandbox silently drops args[2]+, so passing the payload
-  // via args causes writeFileSync to receive undefined and throw — swallowed silently.
-  // Instead, embed the payload directly in the script string in 32KB chunks.
-  const CHUNK = 32 * 1024;
-  for (let i = 0; i < payload.length; i += CHUNK) {
-    const chunk = JSON.stringify(payload.slice(i, i + CHUNK));
-    const mode = i === 0 ? 'writeFileSync' : 'appendFileSync';
+  const chunkSize = 16 * 1024;
+  const runWriteStep = async (op, chunk) => {
     const result = await PluginAPI.executeNodeScript({
-      script: `const fs=require('fs'); fs.${mode}(args[0], ${chunk}); return {success:true};`,
-      args: [filePath],
-      timeout: 10000,
+      script: `
+        const fs = require('fs');
+        const path = require('path');
+        const filePath = path.join(args[0], args[1] + '_response.json');
+        const tmpPath = filePath + '.tmp';
+        const op = args[2];
+        if (op === 'start') {
+          fs.writeFileSync(tmpPath, '', { mode: 0o600 });
+        } else if (op === 'append') {
+          fs.appendFileSync(tmpPath, args[3], 'utf-8');
+        } else if (op === 'finish') {
+          try { fs.unlinkSync(filePath); } catch (e) {}
+          fs.renameSync(tmpPath, filePath);
+        } else {
+          return { success: false, error: 'Unknown response write operation: ' + op };
+        }
+        return { success: true };
+      `,
+      args: [responseDir, commandId, op, chunk || ''],
+      timeout: 5000,
     });
-    const r = (result && result.result && typeof result.result === 'object') ? result.result : result;
-    if (!r || r.success === false) {
-      throw new Error('writeResponse failed: ' + (r && r.error ? r.error : String(r)));
-    }
+    assertNodeResult(result, 'writeResponse ' + op);
+  };
+
+  await runWriteStep('start');
+  for (let i = 0; i < payload.length; i += chunkSize) {
+    await runWriteStep('append', payload.slice(i, i + chunkSize));
   }
+  await runWriteStep('finish');
 }
 
 async function deleteFile(filePath) {
-  await PluginAPI.executeNodeScript({
-    script: `require('fs').unlinkSync(args[0]); return { success: true };`,
+  const result = await PluginAPI.executeNodeScript({
+    script: `
+      const fs = require('fs');
+      fs.unlinkSync(args[0]);
+      return { success: true };
+    `,
     args: [filePath],
     timeout: 5000,
   });
+  assertNodeResult(result, 'deleteFile');
 }
 
 async function executeCommand(command) {
@@ -443,7 +491,7 @@ async function pollCommands() {
       args: [commandDir, lastProcessed],
       timeout: 10000,
     });
-    const r = result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
+    const r = unwrapNodeResult(result);
     if (!r || !r.success || !r.commands) return;
     for (const cmd of r.commands) {
       const cmdId = cmd.data.id || cmd.file.replace('.json', '');
@@ -498,7 +546,7 @@ async function init() {
         timeout: 5000,
       });
       pollTimer = setInterval(pollCommands, POLL_INTERVAL_MS);
-      console.log('MCP Bridge Plugin initialized');
+      console.log('MCP Bridge Plugin initialized', { commandDir, responseDir });
       return;
     } catch (e) {
       console.error('MCP Bridge init attempt ' + attempt + '/' + MAX_RETRIES + ' failed:', e);

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -79,7 +79,7 @@ async function setupDirectories() {
 }
 
 async function writeResponse(commandId, response) {
-  const payload = JSON.stringify(response, null, 2) ?? 'null';
+  const payload = JSON.stringify(response, null, 2) || 'null';
   const filePath = responseDir + '/' + commandId + '_response.json';
   // SP's executeNodeScript sandbox silently drops args[2]+, so passing the payload
   // via args causes writeFileSync to receive undefined and throw — swallowed silently.
@@ -91,11 +91,11 @@ async function writeResponse(commandId, response) {
     const result = await PluginAPI.executeNodeScript({
       script: `const fs=require('fs'); fs.${mode}(args[0], ${chunk}); return {success:true};`,
       args: [filePath],
-      timeout: 5000,
+      timeout: 10000,
     });
     const r = (result && result.result && typeof result.result === 'object') ? result.result : result;
     if (!r || r.success === false) {
-      throw new Error('writeResponse failed: ' + (r && r.error ? r.error : JSON.stringify(r)));
+      throw new Error('writeResponse failed: ' + (r && r.error ? r.error : String(r)));
     }
   }
 }
@@ -456,9 +456,9 @@ async function pollCommands() {
           await writeResponse(cmdId, { success: false, error: e.message || String(e), timestamp: Date.now() });
         } catch (_) {}
       }
+      lastProcessed = Math.max(lastProcessed, cmd.mtime);
       try {
         await deleteFile(cmd.path);
-        lastProcessed = Math.max(lastProcessed, cmd.mtime);
       } catch (e) {
         console.error('deleteFile failed:', e);
       }

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -28,9 +28,11 @@ async function setupDirectories() {
         const xdgData = (typeof process !== 'undefined' && process.env && process.env.XDG_DATA_HOME) || path.join(home, '.local', 'share');
         candidates = [
           path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
-          path.join(xdgData, APP)
+          path.join(xdgData, APP),
+          path.join('/tmp', APP)
         ];
       }
+      const errors = [];
       // Check for mcp_config.json override
       for (const p of candidates) {
         try {
@@ -56,9 +58,11 @@ async function setupDirectories() {
           if (!fs.existsSync(cd)) fs.mkdirSync(cd, { recursive: true, mode: 0o700 });
           if (!fs.existsSync(rd)) fs.mkdirSync(rd, { recursive: true, mode: 0o700 });
           return { success: true, commandDir: cd, responseDir: rd };
-        } catch (e) {}
+        } catch (e) {
+          errors.push(p + ': ' + (e.message || e));
+        }
       }
-      return { success: false, error: 'No writable directory found' };
+      return { success: false, error: 'No writable directory found. Tried:\\n' + errors.join('\\n') };
     `,
     args: [],
     timeout: 10000,

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -79,14 +79,15 @@ async function setupDirectories() {
 }
 
 async function writeResponse(commandId, response) {
+  const payload = JSON.stringify(response, null, 2);
   await PluginAPI.executeNodeScript({
     script: `
       const fs = require('fs');
       const path = require('path');
-      fs.writeFileSync(path.join(args[0], args[1] + '_response.json'), JSON.stringify(args[2], null, 2), { mode: 0o600 });
+      fs.writeFileSync(path.join(args[0], args[1] + '_response.json'), args[2], { mode: 0o600 });
       return { success: true };
     `,
-    args: [responseDir, commandId, response],
+    args: [responseDir, commandId, payload],
     timeout: 5000,
   });
 }
@@ -439,11 +440,12 @@ async function pollCommands() {
     for (const cmd of r.commands) {
       try {
         const response = await executeCommand(cmd.data);
-        await writeResponse(cmd.data.id || cmd.file.replace('.json', ''), response);
+        const cmdId = cmd.data.id || cmd.file.replace('.json', '');
+        await writeResponse(cmdId, response);
         await deleteFile(cmd.path);
         lastProcessed = Math.max(lastProcessed, cmd.mtime);
       } catch (e) {
-        console.error('Command failed:', e);
+        console.error('Command processing failed (' + (cmd.data && cmd.data.action) + '):', e);
       }
     }
   } catch (e) {

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -29,7 +29,7 @@ async function setupDirectories() {
         candidates = [
           path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
           path.join(xdgData, APP),
-          path.join('/tmp', APP)
+          path.join('/tmp', APP) // last-resort: world-writable dir, but mode 0o700 restricts access
         ];
       }
       const errors = [];

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -22,11 +22,13 @@ async function setupDirectories() {
           path.join(home, 'Library', 'Application Support', APP)
         ];
       } else if (os.platform() === 'win32') {
-        candidates = [path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), APP)];
+        const appData = (typeof process !== 'undefined' && process.env && process.env.APPDATA) || path.join(home, 'AppData', 'Roaming');
+        candidates = [path.join(appData, APP)];
       } else {
+        const xdgData = (typeof process !== 'undefined' && process.env && process.env.XDG_DATA_HOME) || path.join(home, '.local', 'share');
         candidates = [
           path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
-          path.join(process.env.XDG_DATA_HOME || path.join(home, '.local', 'share'), APP)
+          path.join(xdgData, APP)
         ];
       }
       // Check for mcp_config.json override

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import type { McpConfig } from './types.js';
 
 const APP_NAME = 'super-productivity-mcp';
+const TMP_ROOT = '/tmp';
 
 export function getCandidatePaths(): string[] {
   const home = homedir();
@@ -17,8 +18,11 @@ export function getCandidatePaths(): string[] {
       return [join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), APP_NAME)];
     default: // linux
       return [
-        join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
+        join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'data', APP_NAME),
+        join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'config', APP_NAME),
         join(process.env.XDG_DATA_HOME ?? join(home, '.local', 'share'), APP_NAME),
+        join(home, 'snap', 'superproductivity', 'common', '.local', 'share', APP_NAME),
+        join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
         join('/tmp', APP_NAME), // last-resort: world-writable dir, but mode 0o700 restricts access
       ];
   }
@@ -30,15 +34,32 @@ function ensureDir(dir: string): void {
   }
 }
 
+function ensureWritableDir(dir: string): void {
+  ensureDir(dir);
+  const testPath = join(dir, `.write-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  writeFileSync(testPath, 'ok', { mode: 0o600 });
+  unlinkSync(testPath);
+}
+
+function ensureIpcDirs(base: string): void {
+  ensureWritableDir(base);
+  ensureWritableDir(join(base, 'plugin_commands'));
+  ensureWritableDir(join(base, 'plugin_responses'));
+}
+
+function isTmpDataDir(dir: string): boolean {
+  return dir === TMP_ROOT || dir.startsWith(`${TMP_ROOT}/`);
+}
+
 export function resolveDataDir(): string {
   const envOverride = process.env.SP_MCP_DATA_DIR;
   if (envOverride) {
-    ensureDir(envOverride);
+    ensureIpcDirs(envOverride);
     // Write mcp_config.json to standard location so plugin can find it
     const standardPaths = getCandidatePaths();
     for (const p of standardPaths) {
       try {
-        ensureDir(p);
+        ensureWritableDir(p);
         const configPath = join(p, 'mcp_config.json');
         const config: McpConfig = { dataDir: envOverride };
         writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
@@ -54,7 +75,10 @@ export function resolveDataDir(): string {
     if (existsSync(configPath)) {
       try {
         const config: McpConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
-        if (config.dataDir && existsSync(config.dataDir)) return config.dataDir;
+        if (config.dataDir && existsSync(config.dataDir) && !isTmpDataDir(config.dataDir)) {
+          ensureIpcDirs(config.dataDir);
+          return config.dataDir;
+        }
       } catch { /* ignore invalid config */ }
     }
   }
@@ -62,7 +86,7 @@ export function resolveDataDir(): string {
   // Probe for first writable path
   for (const p of getCandidatePaths()) {
     try {
-      ensureDir(p);
+      ensureIpcDirs(p);
       return p;
     } catch { /* try next */ }
   }
@@ -80,7 +104,7 @@ export function resolveDirectories(): ResolvedDirs {
   const base = resolveDataDir();
   const commands = join(base, 'plugin_commands');
   const responses = join(base, 'plugin_responses');
-  ensureDir(commands);
-  ensureDir(responses);
+  ensureWritableDir(commands);
+  ensureWritableDir(responses);
   return { base, commands, responses };
 }

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -19,6 +19,7 @@ function getCandidatePaths(): string[] {
       return [
         join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
         join(process.env.XDG_DATA_HOME ?? join(home, '.local', 'share'), APP_NAME),
+        join('/tmp', APP_NAME),
       ];
   }
 }

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -5,7 +5,7 @@ import type { McpConfig } from './types.js';
 
 const APP_NAME = 'super-productivity-mcp';
 
-function getCandidatePaths(): string[] {
+export function getCandidatePaths(): string[] {
   const home = homedir();
   switch (platform()) {
     case 'darwin':
@@ -19,7 +19,7 @@ function getCandidatePaths(): string[] {
       return [
         join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
         join(process.env.XDG_DATA_HOME ?? join(home, '.local', 'share'), APP_NAME),
-        join('/tmp', APP_NAME),
+        join('/tmp', APP_NAME), // last-resort: world-writable dir, but mode 0o700 restricts access
       ];
   }
 }

--- a/tests/unit/directories.test.ts
+++ b/tests/unit/directories.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, platform } from 'node:os';
 
 // We test resolveDataDir by setting SP_MCP_DATA_DIR
 describe('directories', () => {
@@ -37,5 +37,12 @@ describe('directories', () => {
     expect(dirs.responses).toBe(join(customDir, 'plugin_responses'));
     expect(existsSync(dirs.commands)).toBe(true);
     expect(existsSync(dirs.responses)).toBe(true);
+  });
+
+  it('linux candidates include /tmp fallback', async () => {
+    if (platform() !== 'linux') return;
+    const { getCandidatePaths } = await import('../../src/ipc/directories.js');
+    const paths = getCandidatePaths();
+    expect(paths[paths.length - 1]).toBe('/tmp/super-productivity-mcp');
   });
 });

--- a/tests/unit/directories.test.ts
+++ b/tests/unit/directories.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir, platform } from 'node:os';
+import { homedir, tmpdir, platform } from 'node:os';
 
 // We test resolveDataDir by setting SP_MCP_DATA_DIR
 describe('directories', () => {
@@ -44,5 +44,20 @@ describe('directories', () => {
     const { getCandidatePaths } = await import('../../src/ipc/directories.js');
     const paths = getCandidatePaths();
     expect(paths[paths.length - 1]).toBe('/tmp/super-productivity-mcp');
+  });
+
+  it('linux candidates prefer Flatpak app data before /tmp fallback', async () => {
+    if (platform() !== 'linux') return;
+    const { getCandidatePaths } = await import('../../src/ipc/directories.js');
+    const paths = getCandidatePaths();
+    expect(paths[0]).toBe(join(
+      homedir(),
+      '.var',
+      'app',
+      'com.super_productivity.SuperProductivity',
+      'data',
+      'super-productivity-mcp',
+    ));
+    expect(paths.indexOf('/tmp/super-productivity-mcp')).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes all three issues reported in #36:

1. **`process` not defined** — SP's `executeNodeScript` sandbox doesn't expose the `process` global. Wrapped `process.env.APPDATA` and `process.env.XDG_DATA_HOME` with `typeof process !== 'undefined'` guards.

2. **No writable directory on Fedora/sandboxed Linux** — Added `/tmp/super-productivity-mcp` as a last-resort fallback on both the plugin and MCP server side, so they agree on a directory without needing `SP_MCP_DATA_DIR`. Also added error logging that reports each candidate path and why it failed.

3. **Manifest version mismatch** — Fixed `plugin/manifest.json` version from `1.1.1` → `1.2.0` to match `package.json`.

## Changes

- `plugin/plugin.js`: guard `process.env`, add `/tmp` fallback, log errors per candidate
- `src/ipc/directories.ts`: add `/tmp` fallback to Linux candidates
- `plugin/manifest.json`: version bump to `1.2.0`

## Testing

- `npm run build` passes
- All 94 tests pass

Fixes #36