### PR TITLE
fix(ipc): resolve Flatpak directory mismatch

### DIFF
--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -7,6 +7,18 @@ let pollTimer = null;
 let lastProcessed = 0;
 let currentTrackedTask = null;
 
+function unwrapNodeResult(result) {
+  return result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
+}
+
+function assertNodeResult(result, context) {
+  const r = unwrapNodeResult(result);
+  if (!r || !r.success) {
+    throw new Error(context + ': ' + ((r && r.error) || 'Node script failed'));
+  }
+  return r;
+}
+
 async function setupDirectories() {
   const result = await PluginAPI.executeNodeScript({
     script: `
@@ -15,6 +27,8 @@ async function setupDirectories() {
       const os = require('os');
       const home = os.homedir();
       const APP = 'super-productivity-mcp';
+      const TMP_ROOT = '/tmp';
+      const TMP_DATA_DIR = path.join(TMP_ROOT, APP);
       let candidates;
       if (os.platform() === 'darwin') {
         candidates = [
@@ -27,37 +41,53 @@ async function setupDirectories() {
       } else {
         const xdgData = (typeof process !== 'undefined' && process.env && process.env.XDG_DATA_HOME) || path.join(home, '.local', 'share');
         candidates = [
-          path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
+          path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'data', APP),
+          path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'config', APP),
           path.join(xdgData, APP),
+          path.join(home, 'snap', 'superproductivity', 'common', '.local', 'share', APP),
+          path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),
           path.join('/tmp', APP) // last-resort: world-writable dir, but mode 0o700 restricts access
         ];
       }
       const errors = [];
+      const configCandidates = candidates.filter(function(p) { return p !== TMP_DATA_DIR; });
+      function isTmpDataDir(dir) {
+        return dir === TMP_ROOT || dir.indexOf(TMP_ROOT + '/') === 0;
+      }
+      function ensureWritableDir(dir) {
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+        const testFile = path.join(dir, '.write-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        fs.writeFileSync(testFile, 'ok', { mode: 0o600 });
+        fs.unlinkSync(testFile);
+      }
+      function ensureIpcDirs(baseDir) {
+        const cd = path.join(baseDir, 'plugin_commands');
+        const rd = path.join(baseDir, 'plugin_responses');
+        ensureWritableDir(baseDir);
+        ensureWritableDir(cd);
+        ensureWritableDir(rd);
+        return { commandDir: cd, responseDir: rd };
+      }
       // Check for mcp_config.json override
-      for (const p of candidates) {
+      for (const p of configCandidates) {
         try {
           const cfg = path.join(p, 'mcp_config.json');
           if (fs.existsSync(cfg)) {
             const c = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
-            if (c.dataDir && fs.existsSync(c.dataDir)) {
-              const cd = path.join(c.dataDir, 'plugin_commands');
-              const rd = path.join(c.dataDir, 'plugin_responses');
-              if (!fs.existsSync(cd)) fs.mkdirSync(cd, { recursive: true, mode: 0o700 });
-              if (!fs.existsSync(rd)) fs.mkdirSync(rd, { recursive: true, mode: 0o700 });
-              return { success: true, commandDir: cd, responseDir: rd };
+            if (c.dataDir && fs.existsSync(c.dataDir) && !isTmpDataDir(c.dataDir)) {
+              const dirs = ensureIpcDirs(c.dataDir);
+              return { success: true, commandDir: dirs.commandDir, responseDir: dirs.responseDir };
             }
           }
-        } catch (e) {}
+        } catch (e) {
+          errors.push(p + ' config: ' + (e.message || e));
+        }
       }
       // Probe candidates
       for (const p of candidates) {
         try {
-          if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true, mode: 0o700 });
-          const cd = path.join(p, 'plugin_commands');
-          const rd = path.join(p, 'plugin_responses');
-          if (!fs.existsSync(cd)) fs.mkdirSync(cd, { recursive: true, mode: 0o700 });
-          if (!fs.existsSync(rd)) fs.mkdirSync(rd, { recursive: true, mode: 0o700 });
-          return { success: true, commandDir: cd, responseDir: rd };
+          const dirs = ensureIpcDirs(p);
+          return { success: true, commandDir: dirs.commandDir, responseDir: dirs.responseDir };
         } catch (e) {
           errors.push(p + ': ' + (e.message || e));
         }
@@ -68,8 +98,7 @@ async function setupDirectories() {
     timeout: 10000,
   });
   // executeNodeScript wraps result: could be result.result.success or result.success
-  let r = result;
-  if (r && r.success && r.result && typeof r.result === 'object') r = r.result;
+  const r = unwrapNodeResult(result);
   if (r && r.success) {
     commandDir = r.commandDir;
     responseDir = r.responseDir;
@@ -80,24 +109,51 @@ async function setupDirectories() {
 
 async function writeResponse(commandId, response) {
   const payload = JSON.stringify(response, null, 2);
-  await PluginAPI.executeNodeScript({
-    script: `
-      const fs = require('fs');
-      const path = require('path');
-      fs.writeFileSync(path.join(args[0], args[1] + '_response.json'), args[2], { mode: 0o600 });
-      return { success: true };
-    `,
-    args: [responseDir, commandId, payload],
-    timeout: 5000,
-  });
+  const chunkSize = 16 * 1024;
+  const runWriteStep = async (op, chunk) => {
+    const result = await PluginAPI.executeNodeScript({
+      script: `
+        const fs = require('fs');
+        const path = require('path');
+        const filePath = path.join(args[0], args[1] + '_response.json');
+        const tmpPath = filePath + '.tmp';
+        const op = args[2];
+        if (op === 'start') {
+          fs.writeFileSync(tmpPath, '', { mode: 0o600 });
+        } else if (op === 'append') {
+          fs.appendFileSync(tmpPath, args[3], 'utf-8');
+        } else if (op === 'finish') {
+          try { fs.unlinkSync(filePath); } catch (e) {}
+          fs.renameSync(tmpPath, filePath);
+        } else {
+          return { success: false, error: 'Unknown response write operation: ' + op };
+        }
+        return { success: true };
+      `,
+      args: [responseDir, commandId, op, chunk || ''],
+      timeout: 5000,
+    });
+    assertNodeResult(result, 'writeResponse ' + op);
+  };
+
+  await runWriteStep('start');
+  for (let i = 0; i < payload.length; i += chunkSize) {
+    await runWriteStep('append', payload.slice(i, i + chunkSize));
+  }
+  await runWriteStep('finish');
 }
 
 async function deleteFile(filePath) {
-  await PluginAPI.executeNodeScript({
-    script: `require('fs').unlinkSync(args[0]); return { success: true };`,
+  const result = await PluginAPI.executeNodeScript({
+    script: `
+      const fs = require('fs');
+      fs.unlinkSync(args[0]);
+      return { success: true };
+    `,
     args: [filePath],
     timeout: 5000,
   });
+  assertNodeResult(result, 'deleteFile');
 }
 
 async function executeCommand(command) {
@@ -435,7 +491,7 @@ async function pollCommands() {
       args: [commandDir, lastProcessed],
       timeout: 10000,
     });
-    const r = result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
+    const r = unwrapNodeResult(result);
     if (!r || !r.success || !r.commands) return;
     for (const cmd of r.commands) {
       try {
@@ -483,7 +539,7 @@ async function init() {
         timeout: 5000,
       });
       pollTimer = setInterval(pollCommands, POLL_INTERVAL_MS);
-      console.log('MCP Bridge Plugin initialized');
+      console.log('MCP Bridge Plugin initialized', { commandDir, responseDir });
       return;
     } catch (e) {
       console.error('MCP Bridge init attempt ' + attempt + '/' + MAX_RETRIES + ' failed:', e);

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import type { McpConfig } from './types.js';
 
 const APP_NAME = 'super-productivity-mcp';
+const TMP_ROOT = '/tmp';
 
 export function getCandidatePaths(): string[] {
   const home = homedir();
@@ -17,8 +18,11 @@ export function getCandidatePaths(): string[] {
       return [join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), APP_NAME)];
     default: // linux
       return [
-        join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
+        join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'data', APP_NAME),
+        join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'config', APP_NAME),
         join(process.env.XDG_DATA_HOME ?? join(home, '.local', 'share'), APP_NAME),
+        join(home, 'snap', 'superproductivity', 'common', '.local', 'share', APP_NAME),
+        join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP_NAME),
         join('/tmp', APP_NAME), // last-resort: world-writable dir, but mode 0o700 restricts access
       ];
   }
@@ -30,15 +34,32 @@ function ensureDir(dir: string): void {
   }
 }
 
+function ensureWritableDir(dir: string): void {
+  ensureDir(dir);
+  const testPath = join(dir, `.write-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  writeFileSync(testPath, 'ok', { mode: 0o600 });
+  unlinkSync(testPath);
+}
+
+function ensureIpcDirs(base: string): void {
+  ensureWritableDir(base);
+  ensureWritableDir(join(base, 'plugin_commands'));
+  ensureWritableDir(join(base, 'plugin_responses'));
+}
+
+function isTmpDataDir(dir: string): boolean {
+  return dir === TMP_ROOT || dir.startsWith(`${TMP_ROOT}/`);
+}
+
 export function resolveDataDir(): string {
   const envOverride = process.env.SP_MCP_DATA_DIR;
   if (envOverride) {
-    ensureDir(envOverride);
+    ensureIpcDirs(envOverride);
     // Write mcp_config.json to standard location so plugin can find it
     const standardPaths = getCandidatePaths();
     for (const p of standardPaths) {
       try {
-        ensureDir(p);
+        ensureWritableDir(p);
         const configPath = join(p, 'mcp_config.json');
         const config: McpConfig = { dataDir: envOverride };
         writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
@@ -54,7 +75,10 @@ export function resolveDataDir(): string {
     if (existsSync(configPath)) {
       try {
         const config: McpConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
-        if (config.dataDir && existsSync(config.dataDir)) return config.dataDir;
+        if (config.dataDir && existsSync(config.dataDir) && !isTmpDataDir(config.dataDir)) {
+          ensureIpcDirs(config.dataDir);
+          return config.dataDir;
+        }
       } catch { /* ignore invalid config */ }
     }
   }
@@ -62,7 +86,7 @@ export function resolveDataDir(): string {
   // Probe for first writable path
   for (const p of getCandidatePaths()) {
     try {
-      ensureDir(p);
+      ensureIpcDirs(p);
       return p;
     } catch { /* try next */ }
   }
@@ -80,7 +104,7 @@ export function resolveDirectories(): ResolvedDirs {
   const base = resolveDataDir();
   const commands = join(base, 'plugin_commands');
   const responses = join(base, 'plugin_responses');
-  ensureDir(commands);
-  ensureDir(responses);
+  ensureWritableDir(commands);
+  ensureWritableDir(responses);
   return { base, commands, responses };
 }

--- a/tests/unit/directories.test.ts
+++ b/tests/unit/directories.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir, platform } from 'node:os';
+import { homedir, tmpdir, platform } from 'node:os';
 
 // We test resolveDataDir by setting SP_MCP_DATA_DIR
 describe('directories', () => {
@@ -44,5 +44,20 @@ describe('directories', () => {
     const { getCandidatePaths } = await import('../../src/ipc/directories.js');
     const paths = getCandidatePaths();
     expect(paths[paths.length - 1]).toBe('/tmp/super-productivity-mcp');
+  });
+
+  it('linux candidates prefer Flatpak app data before /tmp fallback', async () => {
+    if (platform() !== 'linux') return;
+    const { getCandidatePaths } = await import('../../src/ipc/directories.js');
+    const paths = getCandidatePaths();
+    expect(paths[0]).toBe(join(
+      homedir(),
+      '.var',
+      'app',
+      'com.super_productivity.SuperProductivity',
+      'data',
+      'super-productivity-mcp',
+    ));
+    expect(paths.indexOf('/tmp/super-productivity-mcp')).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Fixes the remaining Flatpak IPC directory mismatch found while testing #36 on Fedora + Flathub.

This PR builds on #37. The earlier fixes got the plugin initializing correctly, but the bridge could still time out because the MCP server and the Super Productivity plugin were resolving different IPC locations, especially when stale `mcp_config.json` files pointed back to `/tmp`.

## What changed

- Prefer Flatpak data/config paths before Snap and `/tmp` on Linux:
  - `~/.var/app/com.super_productivity.SuperProductivity/data/super-productivity-mcp`
  - `~/.var/app/com.super_productivity.SuperProductivity/config/super-productivity-mcp`
- Keep Snap candidates, but lower their priority.
- Keep `/tmp/super-productivity-mcp` only as a last-resort fallback.
- Probe candidate IPC directories with real write/delete checks before accepting them.
- Ignore persisted `mcp_config.json` overrides that point anywhere under `/tmp`.
- Write plugin responses through a temporary file before renaming to the final response file.
- Add a unit test covering Flatpak path priority on Linux.

## Why

On Fedora with Super Productivity installed from Flathub, `/tmp` is not a reliable shared IPC location. The host MCP server and the Flatpak app can print the same textual `/tmp/super-productivity-mcp` path while still not seeing the same files.

I also found stale `mcp_config.json` values redirecting the bridge to:

```txt
/tmp/super-productivity-mcp
/tmp/sp-mcp-test-.../dirs-test
```

That caused `debug_directories` to resolve to `/tmp` paths even after removing `SP_MCP_DATA_DIR` from the MCP TOML config.

## Manual verification

Final Codex MCP config did not need `SP_MCP_DATA_DIR`:

```toml
[mcp_servers.super_productivity]
command = "node"
args = ["/home/jefferson/Desktop/teste/Super-Productivity-MCP/dist/index.js"]
```

`debug_directories` resolved to the Flatpak data path:

```json
{
  "base": "/home/jefferson/.var/app/com.super_productivity.SuperProductivity/data/super-productivity-mcp",
  "commands": "/home/jefferson/.var/app/com.super_productivity.SuperProductivity/data/super-productivity-mcp/plugin_commands",
  "responses": "/home/jefferson/.var/app/com.super_productivity.SuperProductivity/data/super-productivity-mcp/plugin_responses",
  "exists": {
    "base": true,
    "commands": true,
    "responses": true
  }
}
```

The plugin initialized with the same paths, and `get_tasks` returned tasks successfully.

## Validation

```bash
npm test
npm run typecheck
npm run lint
npm run build
```

All checks passed.
