### PR TITLE
feat(plugin): use plugin.onReady() for startup init

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Include these in task titles and they are parsed automatically:
 
 ## Troubleshooting
 
-**Requires SP ≥ 18.6.0.** If the plugin does not respond after install, toggle it off and on in Settings → Plugins.
+**Requires SP ≥ 18.6.0.** If the plugin does not respond after install, toggle it off and on in Settings → Plugins. No restart needed.
 
 **Commands timing out?** Ask *"Show debug info for Super Productivity"* to check that both sides are using the same data directory. Mac App Store users may need to set `SP_MCP_DATA_DIR`.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Include these in task titles and they are parsed automatically:
 
 ## Troubleshooting
 
-**Plugin not loading?** Update to SP ≥ 18.6.0 — older versions have a cold-boot race that can prevent the plugin from initializing. On SP ≥ 18.6.0 this is fixed and no restart is needed; just toggle the plugin off and on in Settings → Plugins. On older versions, a restart after toggling may help.
+**Plugin not loading?** Update to SP ≥ 18.6.0 — older versions have a cold-boot race that can prevent the plugin from initializing. On SP ≥ 18.6.0 this is fixed and no restart is needed; just **toggle the plugin off and on** in Settings → Plugins. On older versions, a restart after toggling may help.
 
 **Commands timing out?** Ask *"Show debug info for Super Productivity"* to check that both sides are using the same data directory. Mac App Store users may need to set `SP_MCP_DATA_DIR`.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Include these in task titles and they are parsed automatically:
 
 ## Troubleshooting
 
-**Plugin not responding after install?** Toggle the plugin off and on in Settings → Plugins, then restart SP.
+**Requires SP ≥ 18.6.0.** If the plugin does not respond after install, toggle it off and on in Settings → Plugins.
 
 **Commands timing out?** Ask *"Show debug info for Super Productivity"* to check that both sides are using the same data directory. Mac App Store users may need to set `SP_MCP_DATA_DIR`.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Include these in task titles and they are parsed automatically:
 
 ## Troubleshooting
 
-**Plugin not responding after install?** Toggle the plugin off and on in Settings → Plugins — this is a [known SP startup issue](https://github.com/super-productivity/super-productivity/issues/7326).
+**Plugin not responding after install?** Toggle the plugin off and on in Settings → Plugins, then restart SP.
 
 **Commands timing out?** Ask *"Show debug info for Super Productivity"* to check that both sides are using the same data directory. Mac App Store users may need to set `SP_MCP_DATA_DIR`.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Include these in task titles and they are parsed automatically:
 
 ## Troubleshooting
 
-**Requires SP ≥ 18.6.0.** If the plugin does not respond after install, toggle it off and on in Settings → Plugins. No restart needed.
+**Plugin not loading?** Update to SP ≥ 18.6.0 — older versions have a cold-boot race that can prevent the plugin from initializing. On SP ≥ 18.6.0 this is fixed and no restart is needed; just toggle the plugin off and on in Settings → Plugins. On older versions, a restart after toggling may help.
 
 **Commands timing out?** Ask *"Show debug info for Super Productivity"* to check that both sides are using the same data directory. Mac App Store users may need to set `SP_MCP_DATA_DIR`.
 

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -453,7 +453,7 @@ async function executeCommand(command) {
         break;
       }
       case 'ping':
-        result = { pong: true, pluginVersion: '1.2.1', protocolVersion: PROTOCOL_VERSION };
+        result = { pong: true, pluginVersion: '1.3.0', protocolVersion: PROTOCOL_VERSION };
         break;
       default:
         return { success: false, error: `Unknown command action: ${command.action}`, timestamp: Date.now() };
@@ -516,48 +516,32 @@ async function pollCommands() {
   }
 }
 
-// Initialize with retry — nodeExecution permission may not be ready on first plugin activation
-const MAX_RETRIES = 10;
-const INITIAL_DELAY_MS = 1000;
-
 async function init() {
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
-  let delay = INITIAL_DELAY_MS;
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      await setupDirectories();
-      // FR-020: Clean stale files on startup (>5min old)
-      await PluginAPI.executeNodeScript({
-        script: `
-          const fs = require('fs');
-          const path = require('path');
-          const now = Date.now();
-          for (const dir of [args[0], args[1]]) {
-            try {
-              for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json'))) {
-                const fp = path.join(dir, f);
-                if (now - fs.statSync(fp).mtimeMs > 300000) fs.unlinkSync(fp);
-              }
-            } catch (e) {}
+  await setupDirectories();
+  // FR-020: Clean stale files on startup (>5min old)
+  await PluginAPI.executeNodeScript({
+    script: `
+      const fs = require('fs');
+      const path = require('path');
+      const now = Date.now();
+      for (const dir of [args[0], args[1]]) {
+        try {
+          for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json'))) {
+            const fp = path.join(dir, f);
+            if (now - fs.statSync(fp).mtimeMs > 300000) fs.unlinkSync(fp);
           }
-          return { success: true };
-        `,
-        args: [commandDir, responseDir],
-        timeout: 5000,
-      });
-      pollTimer = setInterval(pollCommands, POLL_INTERVAL_MS);
-      console.log('MCP Bridge Plugin initialized', { commandDir, responseDir });
-      return;
-    } catch (e) {
-      console.error('MCP Bridge init attempt ' + attempt + '/' + MAX_RETRIES + ' failed:', e);
-      if (attempt < MAX_RETRIES) {
-        await new Promise(function(r) { setTimeout(r, delay); });
-        delay = Math.min(delay * 2, 10000);
+        } catch (e) {}
       }
-    }
-  }
-  console.error('MCP Bridge init failed after all retries');
+      return { success: true };
+    `,
+    args: [commandDir, responseDir],
+    timeout: 5000,
+  });
+  pollTimer = setInterval(pollCommands, POLL_INTERVAL_MS);
+  console.log('MCP Bridge Plugin initialized', { commandDir, responseDir });
 }
 
-// Delay first attempt to let SP finish granting permissions
-setTimeout(init, 500);
+// onReady fires after SP confirms the Node.js IPC bridge is available (with retry).
+// This replaces the old setTimeout(init, 500) workaround for cold-boot races.
+PluginAPI.onReady(init);

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -543,5 +543,9 @@ async function init() {
 }
 
 // onReady fires after SP confirms the Node.js IPC bridge is available (with retry).
-// This replaces the old setTimeout(init, 500) workaround for cold-boot races.
-PluginAPI.onReady(init);
+// Fall back to setTimeout for SP < 18.6.0 which lacks onReady.
+if (typeof PluginAPI.onReady === 'function') {
+  PluginAPI.onReady(init);
+} else {
+  setTimeout(init, 500);
+}


### PR DESCRIPTION
Now that [super-productivity/super-productivity#7578](https://github.com/super-productivity/super-productivity/pull/7578) is merged and released, the plugin can use the new `plugin.onReady()` API instead of the fragile `setTimeout` workaround.

## Changes

**`plugin.js`**
- Replace `setTimeout(init, 500)` with `PluginAPI.onReady(init)`
- Remove the 10-attempt retry loop in `init()` — SP now handles the IPC bridge ping with retry (3 attempts, 1s/2s delays) before firing the callback, making the plugin-side retry redundant
- `init()` is now a simple linear function
- Bump plugin version to `1.3.0`

**`README.md`**
- Remove the "toggle plugin off/on" workaround note that referenced the now-fixed SP issue #7326

## Requires

SP >= the release that includes #7578.