### PR TITLE
docs: Run w/o npx, one-liner for Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+plugin.zip
 *.log
 .env*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Config file locations:
 - **Claude Desktop (macOS):** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Claude Desktop (Windows):** `%APPDATA%\Claude\claude_desktop_config.json`
 
+For **Claude Code**, don't edit the config file by hand — use the CLI:
+
+```bash
+# user scope (everywhere), project scope (-s project), or local scope (default)
+claude mcp add -s user super-productivity npx -- -y super-productivity-mcp
+```
+
+To verify, run `claude mcp list`. Restart the session to load the server. Swap `npx -- -y super-productivity-mcp` for `super-productivity-mcp` (global install) or `node /absolute/path/to/dist/index.js` (from source) — see [Running without npx](#running-without-npx).
+
 ### 3. Verify
 
 Ask your AI assistant: *"Check the Super Productivity connection"*

--- a/README.md
+++ b/README.md
@@ -62,6 +62,55 @@ Config file locations:
 
 Ask your AI assistant: *"Check the Super Productivity connection"*
 
+## Running without npx
+
+`npx` is convenient but fetches the package on every cold cache and needs network access. If you'd rather pin a local copy, pick one of the options below.
+
+### Option A — Global install
+
+```bash
+npm install -g super-productivity-mcp
+super-productivity-mcp --extract-plugin   # optional: write plugin.zip to cwd
+```
+
+Then point your MCP client at the installed binary:
+
+```json
+{
+  "mcpServers": {
+    "super-productivity": {
+      "command": "super-productivity-mcp"
+    }
+  }
+}
+```
+
+If the binary isn't found, your MCP client may not inherit your shell's `PATH`. Use the absolute path from `which super-productivity-mcp` (or `npm bin -g` to locate the npm global bin directory) as `command`.
+
+### Option B — From source
+
+```bash
+git clone https://github.com/b0x42/Super-Productivity-MCP.git
+cd Super-Productivity-MCP
+npm install
+npm run build              # produces dist/index.js and dist/plugin.zip
+```
+
+Then run the server directly with `node`:
+
+```json
+{
+  "mcpServers": {
+    "super-productivity": {
+      "command": "node",
+      "args": ["/absolute/path/to/Super-Productivity-MCP/dist/index.js"]
+    }
+  }
+}
+```
+
+The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm run build`.
+
 ## Prerequisites
 
 - [Super Productivity](https://super-productivity.com) >= 14.0.0

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then point your MCP client at the installed binary:
 }
 ```
 
-If the binary isn't found, your MCP client may not inherit your shell's `PATH`. Use the absolute path from `which super-productivity-mcp` (or `npm bin -g` to locate the npm global bin directory) as `command`.
+If the binary isn't found, your MCP client may not inherit your shell's `PATH`. Use the absolute path from `which super-productivity-mcp` as `command` — or, if `which` doesn't resolve it, point at `$(npm config get prefix)/bin/super-productivity-mcp` (on macOS/Linux).
 
 ### Option B — From source
 


### PR DESCRIPTION
A couple of docs updates on how to run the MCP. 

Also adds plugin.zip to `.gitignore`.