### PR TITLE
feat(tools): add get_task_repeat_cfgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 | `get_tags` | List all tags |
 | `create_tag` | Create a new tag |
 | `update_tag` | Update tag properties |
+| `get_task_repeat_cfgs` | List all recurring task configurations (schedule, cadence, day-of-week settings) |
 | `get_worklog` | Time tracking summary for a date range |
 | `show_notification` | Show a snackbar in SP's UI |
 | `check_connection` | Verify SP is running and the plugin is responding |

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -452,6 +452,14 @@ async function executeCommand(command) {
         result = { parentId, subtaskIds };
         break;
       }
+      case 'getTaskRepeatCfgs': {
+        const state = await PluginAPI.getAppState();
+        // SP stores taskRepeatCfgs as { [id]: cfg } — convert to array so MCP consumers
+        // don't need to know the internal map shape (consistent with get_projects / get_tags).
+        const cfgMap = (state && state.taskRepeatCfgs) || {};
+        result = Object.values(cfgMap);
+        break;
+      }
       case 'ping':
         result = { pong: true, pluginVersion: '1.3.0', protocolVersion: PROTOCOL_VERSION };
         break;

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -526,4 +526,17 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       });
     },
   );
+
+  server.registerTool(
+    'get_task_repeat_cfgs',
+    {
+      description: 'Get all recurring task configurations (taskRepeatCfg) from Super Productivity. Returns repeat schedules with their cycle, frequency, day settings, and associated task metadata.',
+      inputSchema: {},
+    },
+    async () => {
+      const res = await sendCommand(dirs, 'getTaskRepeatCfgs');
+      if (!res.success) return errorResult(res.error ?? 'Failed to get repeat configs');
+      return okResult({ repeatCfgs: res.result });
+    },
+  );
 }

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -604,4 +604,39 @@ describe('task tool logic', () => {
       expect(totalActual / totalEstimate).toBeCloseTo(4000000 / 3600000);
     });
   });
+
+  describe('get_task_repeat_cfgs via sendCommand', () => {
+    it('returns repeat configs array on success', async () => {
+      const cfgs = [
+        { id: 'cfg-1', title: 'Weekly review', repeatCycle: 'WEEKLY', repeatEvery: 1, isPaused: false, tagIds: [], projectId: null },
+        { id: 'cfg-2', title: 'Daily standup', repeatCycle: 'DAILY', repeatEvery: 1, isPaused: false, tagIds: [], projectId: null },
+      ];
+      mockSend.mockResolvedValueOnce(mockResponse(cfgs));
+      const res = await sendCommand(dirs, 'getTaskRepeatCfgs');
+      expect(res.success).toBe(true);
+      expect(res.result).toEqual(cfgs);
+      expect(mockSend).toHaveBeenCalledWith(dirs, 'getTaskRepeatCfgs');
+    });
+
+    it('returns empty array when no repeat configs exist', async () => {
+      mockSend.mockResolvedValueOnce(mockResponse([]));
+      const res = await sendCommand(dirs, 'getTaskRepeatCfgs');
+      expect(res.success).toBe(true);
+      expect(res.result).toEqual([]);
+    });
+
+    it('includes paused configs with isPaused: true', async () => {
+      const cfgs = [{ id: 'cfg-3', title: 'Paused task', repeatCycle: 'MONTHLY', repeatEvery: 1, isPaused: true, tagIds: [], projectId: null }];
+      mockSend.mockResolvedValueOnce(mockResponse(cfgs));
+      const res = await sendCommand(dirs, 'getTaskRepeatCfgs');
+      expect((res.result as typeof cfgs)[0].isPaused).toBe(true);
+    });
+
+    it('propagates error when SP state unavailable', async () => {
+      mockSend.mockResolvedValueOnce({ success: false, error: 'Failed to get repeat configs', timestamp: Date.now() });
+      const res = await sendCommand(dirs, 'getTaskRepeatCfgs');
+      expect(res.success).toBe(false);
+      expect(res.error).toBe('Failed to get repeat configs');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `get_task_repeat_cfgs` MCP tool — returns all recurring task configurations from SP's app state
- Adds `getTaskRepeatCfgs` case to plugin.js using `PluginAPI.getAppState().taskRepeatCfgs`
- Converts SP's internal `{ [id]: cfg }` map to an array for consistent response shape

## Why read-only

Create/update/delete for repeat configs requires SP to expose typed `PluginAPI` methods wrapping `TaskRepeatCfgService`. The raw `dispatchAction` approach was rejected upstream (SP PR [#7710](https://github.com/super-productivity/super-productivity/pull/7710)) due to sync/op-log safety issues. Tracked in issue #51.

## Test plan

- [x] 4 unit tests added: success, empty state, paused config included, error propagation
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] 100/100 tests pass

### Manual verification (requires SP ≤ 18.9.1 — see note below)

1. Build plugin: `npm run build` → `dist/plugin.zip`
2. Reinstall plugin in SP from `dist/plugin.zip`
3. In your MCP client, call `get_task_repeat_cfgs`
4. Expected: array of all repeat configs configured in SP
5. Expected with no repeat configs: `{ "repeatCfgs": [] }` — not an error

> **Note on SP version**: SP v18.10.0 blocks `nodeExecution` for uploaded plugins (see issue #55). Test against SP ≤ 18.9.1 until the bundled plugin path is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)