### PR TITLE
fix: return non-null success payloads from mutation handlers

### DIFF
--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -29,7 +29,7 @@ export function registerProjectTools(server: McpServer, dirs: ResolvedDirs): voi
   }, async () => {
     const res = await sendCommand(dirs, 'getAllProjects');
     if (!res.success) return errorResult(res.error ?? 'Failed to get projects');
-    return okResult(res.result);
+    return okResult(res.result ?? []);
   });
 
   server.registerTool('update_project', {
@@ -46,6 +46,6 @@ export function registerProjectTools(server: McpServer, dirs: ResolvedDirs): voi
     if (color !== undefined) data.theme = { primary: color };
     const res = await sendCommand(dirs, 'updateProject', { projectId: project_id, data });
     if (!res.success) return errorResult(res.error ?? 'Failed to update project');
-    return okResult(res.result);
+    return okResult(res.result ?? { updated: true, project_id });
   });
 }

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -27,7 +27,7 @@ export function registerTagTools(server: McpServer, dirs: ResolvedDirs): void {
   }, async () => {
     const res = await sendCommand(dirs, 'getAllTags');
     if (!res.success) return errorResult(res.error ?? 'Failed to get tags');
-    return okResult(res.result);
+    return okResult(res.result ?? []);
   });
 
   server.registerTool('update_tag', {
@@ -46,6 +46,6 @@ export function registerTagTools(server: McpServer, dirs: ResolvedDirs): void {
     if (icon !== undefined) data.icon = icon;
     const res = await sendCommand(dirs, 'updateTag', { tagId: tag_id, data });
     if (!res.success) return errorResult(res.error ?? 'Failed to update tag');
-    return okResult(res.result);
+    return okResult(res.result ?? { updated: true, tag_id });
   });
 }

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -197,7 +197,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
 
       const res = await sendCommand(dirs, 'updateTask', { taskId: task_id, data });
       if (!res.success) return errorResult(res.error ?? 'Failed to update task');
-      return okResult(res.result);
+      return okResult(res.result ?? { updated: true, task_id });
     },
   );
 
@@ -214,7 +214,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_id?.trim()) return errorResult('task_id is required');
       const res = await sendCommand(dirs, 'setTaskDone', { taskId: task_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to complete task');
-      return okResult(res.result);
+      return okResult(res.result ?? { completed: true, task_id });
     },
   );
 
@@ -233,7 +233,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!tag_id?.trim()) return errorResult('tag_id is required');
       const res = await sendCommand(dirs, 'addTagToTask', { taskId: task_id, tagId: tag_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to add tag');
-      return okResult(null);
+      return okResult({ added: true, task_id, tag_id });
     },
   );
 
@@ -252,7 +252,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!tag_id?.trim()) return errorResult('tag_id is required');
       const res = await sendCommand(dirs, 'removeTagFromTask', { taskId: task_id, tagId: tag_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to remove tag');
-      return okResult(null);
+      return okResult({ removed: true, task_id, tag_id });
     },
   );
 
@@ -266,7 +266,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
     async () => {
       const res = await sendCommand(dirs, 'loadCurrentTask', {});
       if (!res.success) return errorResult(res.error ?? 'Failed to get current task');
-      return okResult(res.result ?? null);
+      return okResult(res.result ?? { currentTask: null });
     },
   );
 
@@ -283,7 +283,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_id?.trim()) return errorResult('task_id is required');
       const res = await sendCommand(dirs, 'startTask', { taskId: task_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to start task');
-      return okResult(null);
+      return okResult({ started: true, task_id });
     },
   );
 
@@ -297,7 +297,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
     async () => {
       const res = await sendCommand(dirs, 'stopTask', {});
       if (!res.success) return errorResult(res.error ?? 'Failed to stop task');
-      return okResult(null);
+      return okResult({ stopped: true });
     },
   );
 
@@ -367,7 +367,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!project_id?.trim()) return errorResult('project_id is required');
       const res = await sendCommand(dirs, 'moveTaskToProject', { taskId: task_id, projectId: project_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to move task');
-      return okResult(null);
+      return okResult({ moved: true, task_id, project_id });
     },
   );
 
@@ -387,7 +387,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!context_id?.trim()) return errorResult('context_id is required');
       const res = await sendCommand(dirs, 'reorderTasks', { taskIds: task_ids, contextId: context_id, contextType: context_type });
       if (!res.success) return errorResult(res.error ?? 'Failed to reorder tasks');
-      return okResult(null);
+      return okResult({ reordered: true });
     },
   );
 
@@ -404,7 +404,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_id?.trim()) return errorResult('task_id is required');
       const res = await sendCommand(dirs, 'deleteTask', { taskId: task_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to delete task');
-      return okResult(null);
+      return okResult({ deleted: true, task_id });
     },
   );
 


### PR DESCRIPTION
## Problem

Several mutation tools (start_task, stop_task, move_task_to_project, reorder_tasks, delete_task) return `okResult(null)` on success. MCPHub's `$smart` route dereferences `.code` on the result payload, which crashes with:

```
TypeError | Cannot read properties of null (reading 'code')
```

## Root cause

The MCP protocol spec allows null results, but MCPHub's smart routing implementation assumes all successful responses contain a non-null object. This affects both read operations (get_current_task) and all mutations that return bare `okResult(null)`.

## Changes

All 3 source files in `src/tools/`:

### `src/tools/tasks.ts`
- `start_task`: `okResult({ started: true, task_id })`
- `stop_task`: `okResult({ stopped: true })`
- `move_task_to_project`: `okResult({ moved: true, task_id, project_id })`
- `reorder_tasks`: `okResult({ reordered: true })`
- `delete_task`: `okResult({ deleted: true, task_id })`
- `get_current_task`: `okResult(res.result ?? { currentTask: null })`
- `update_task`: `okResult(res.result ?? { updated: true, task_id })`
- `complete_task`: `okResult(res.result ?? { completed: true, task_id })`

### `src/tools/tags.ts`
- `get_tags`: `okResult(res.result ?? [])`
- `update_tag`: `okResult(res.result ?? { updated: true, tag_id })`

### `src/tools/projects.ts`
- `get_projects`: `okResult(res.result ?? [])`
- `update_project`: `okResult(res.result ?? { updated: true, project_id })`

## Verification

- All 100 existing unit tests pass
- Full regression pass against live MCPHub: all 10 previously failing operations now return valid responses

Closes #60