### PR TITLE
fix(tools): return { success: true } from void mutations instead of null

### DIFF
--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -260,13 +260,13 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
   server.registerTool(
     'get_current_task',
     {
-      description: 'Get the currently time-tracked task in Super Productivity. Returns null when no task has an active timer.',
+      description: 'Get the currently time-tracked task in Super Productivity. Returns { task: null } when no task has an active timer.',
       inputSchema: {},
     },
     async () => {
       const res = await sendCommand(dirs, 'loadCurrentTask', {});
       if (!res.success) return errorResult(res.error ?? 'Failed to get current task');
-      return okResult(res.result ?? null);
+      return okResult({ task: res.result ?? null });
     },
   );
 

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -233,7 +233,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!tag_id?.trim()) return errorResult('tag_id is required');
       const res = await sendCommand(dirs, 'addTagToTask', { taskId: task_id, tagId: tag_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to add tag');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -252,7 +252,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!tag_id?.trim()) return errorResult('tag_id is required');
       const res = await sendCommand(dirs, 'removeTagFromTask', { taskId: task_id, tagId: tag_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to remove tag');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -283,7 +283,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_id?.trim()) return errorResult('task_id is required');
       const res = await sendCommand(dirs, 'startTask', { taskId: task_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to start task');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -297,7 +297,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
     async () => {
       const res = await sendCommand(dirs, 'stopTask', {});
       if (!res.success) return errorResult(res.error ?? 'Failed to stop task');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -367,7 +367,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!project_id?.trim()) return errorResult('project_id is required');
       const res = await sendCommand(dirs, 'moveTaskToProject', { taskId: task_id, projectId: project_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to move task');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -387,7 +387,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!context_id?.trim()) return errorResult('context_id is required');
       const res = await sendCommand(dirs, 'reorderTasks', { taskIds: task_ids, contextId: context_id, contextType: context_type });
       if (!res.success) return errorResult(res.error ?? 'Failed to reorder tasks');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 
@@ -404,7 +404,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_id?.trim()) return errorResult('task_id is required');
       const res = await sendCommand(dirs, 'deleteTask', { taskId: task_id });
       if (!res.success) return errorResult(res.error ?? 'Failed to delete task');
-      return okResult(null);
+      return okResult({ success: true });
     },
   );
 


### PR DESCRIPTION
## Summary

- All void tool handlers (`add_tag_to_task`, `remove_tag_from_task`, `start_task`, `stop_task`, `move_task_to_project`, `reorder_tasks`, `delete_task`) now return `{ "success": true }` instead of `null`
- Prevents MCPHub's `$smart` route from crashing when it JSON-parses the MCP content text and accesses `.code` on `null`
- Root cause is a MCPHub bug ([mcphub#922](https://github.com/samanhappy/mcphub/issues/922)) but returning a structured object is better practice regardless

Fixes #60

## Test plan

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Reporter verifies fix on MCPHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)