### PR TITLE
fix: use dueWithTime for task scheduling instead of legacy plannedAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Include these in task titles and they are parsed automatically:
 
 | Tool | Issue | Status |
 |------|-------|--------|
-| `plan_tasks_for_today` | Sets `plannedAt` on the task but does not add it to SP's internal Planner store, so the task may not appear in the Today view. | Upstream request: [super-productivity#7495](https://github.com/super-productivity/super-productivity/issues/7495) |
+| `plan_tasks_for_today` | Sets `dueWithTime` (SP's current scheduling field — `plannedAt` is legacy and ignored by the UI) so tasks appear in Today and Schedule views. | Fixed in this release |
 
 ## License
 

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -232,12 +232,12 @@ async function executeCommand(command) {
           result = await PluginAPI.addTask({ ...d, title: cleanTitle });
         }
 
-        // Set dueDay only — plannedAt is independent (due date ≠ planned for today).
+        // Set dueDay only — dueWithTime is independent (due date ≠ planned for today).
         // Clear both when no @date syntax so inbox tasks don't inherit stale schedules.
         if (result && dueDay) {
           await PluginAPI.updateTask(result, { dueDay });
         } else if (result) {
-          await PluginAPI.updateTask(result, { plannedAt: null, dueDay: null });
+          await PluginAPI.updateTask(result, { dueWithTime: null, dueDay: null });
         }
         break;
       }
@@ -254,13 +254,13 @@ async function executeCommand(command) {
       }
       case 'updateTask': {
         const updateData = command.data || {};
-        // SP auto-sets plannedAt when dueDay changes. Preserve existing value unless
-        // caller explicitly included plannedAt in the update.
-        if ('dueDay' in updateData && !('plannedAt' in updateData)) {
+        // SP auto-sets dueWithTime when dueDay changes. Preserve existing value unless
+        // caller explicitly included dueWithTime in the update.
+        if ('dueDay' in updateData && !('dueWithTime' in updateData)) {
           const allTasksForUpdate = await PluginAPI.getTasks();
           const taskForUpdate = allTasksForUpdate.find(t => t.id === command.taskId);
-          const currentPlannedAt = taskForUpdate ? (taskForUpdate.plannedAt ?? null) : null;
-          result = await PluginAPI.updateTask(command.taskId, { ...updateData, plannedAt: currentPlannedAt });
+          const currentDueWithTime = taskForUpdate ? (taskForUpdate.dueWithTime ?? null) : null;
+          result = await PluginAPI.updateTask(command.taskId, { ...updateData, dueWithTime: currentDueWithTime });
         } else {
           result = await PluginAPI.updateTask(command.taskId, updateData);
         }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -11,6 +11,7 @@ interface TaskRecord {
   parentId?: string | null;
   tagIds: string[];
   dueDay?: string | null;
+  dueWithTime?: number | null;
   plannedAt?: number | null;
   timeEstimate: number;
   timeSpent: number;
@@ -24,7 +25,7 @@ function shapeTask(t: TaskRecord) {
     projectId: t.projectId,
     tagIds: t.tagIds,
     dueDay: t.dueDay ?? null,
-    plannedAt: t.plannedAt ?? null,
+    plannedAt: t.dueWithTime ?? t.plannedAt ?? null,
     timeEstimate: t.timeEstimate,
     timeSpent: t.timeSpent,
     parentId: t.parentId ?? null,

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -48,7 +48,7 @@ export function applyTriageFilters(
     const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
     const startOfTomorrow = startOfToday + 86_400_000;
     result = result.filter(t => {
-      const p = t.plannedAt;
+      const p = t.dueWithTime ?? t.plannedAt;
       return p != null && p >= startOfToday && p < startOfTomorrow;
     });
   }
@@ -81,7 +81,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       // unless the title contains @date syntax (which SP will parse into a date itself).
       const hasDateSyntax = /@/.test(title);
       if (!hasDateSyntax) {
-        data.plannedAt = null;
+        data.dueWithTime = null;
         data.dueDay = null;
       }
 
@@ -117,7 +117,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
         parents_only: z.boolean().optional().default(false).describe('Exclude subtasks — return only top-level tasks'),
         overdue: z.boolean().optional().default(false).describe('Return only tasks with a due date strictly before today'),
         unscheduled: z.boolean().optional().default(false).describe('Return only tasks with no due date and no scheduled time'),
-        planned_for_today: z.boolean().optional().default(false).describe('Return only tasks planned for today (via plannedAt timestamp)'),
+        planned_for_today: z.boolean().optional().default(false).describe('Return only tasks planned for today (via dueWithTime/plannedAt timestamp)'),
         recurring_only: z.boolean().optional().default(false).describe('Return only recurring tasks (those with a repeatCfgId)'),
         fields: z.array(z.string()).optional().describe('Return only these fields per task (e.g. ["id", "title", "dueDay"]). Omit for full objects.'),
       },
@@ -172,7 +172,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
         notes: z.string().optional().describe('New notes'),
         is_done: z.boolean().optional().describe('Mark as done/undone'),
         due_day: z.string().optional().describe('Due date in ISO format (e.g. 2026-04-20), or empty string to clear'),
-        planned_at: z.number().nullable().optional().describe('Unix ms timestamp to plan task for a specific time (e.g. start of today = plan for today). Pass null to unplan. Independent from due_day.'),
+        planned_at: z.number().nullable().optional().describe('Unix ms timestamp to schedule the task for a specific time (written as dueWithTime — SP\'s current scheduling field; plannedAt is legacy). Pass null to unschedule. Independent from due_day.'),
         time_estimate: z.number().optional().describe('Time estimate in milliseconds'),
         time_spent: z.number().optional().describe('Time spent in milliseconds'),
         tag_ids: z.array(z.string()).optional().describe('Bulk-replace all tags with this list (FR-003)'),
@@ -189,7 +189,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
         data.doneOn = is_done ? Date.now() : null;
       }
       if (due_day !== undefined) data.dueDay = due_day || null;
-      if (planned_at !== undefined) data.plannedAt = planned_at;
+      if (planned_at !== undefined) data.dueWithTime = planned_at;
       if (time_estimate !== undefined) data.timeEstimate = time_estimate;
       if (time_spent !== undefined) data.timeSpent = time_spent;
       // tag_ids replaces the entire tag list; use add_tag_to_task / remove_tag_from_task for incremental changes
@@ -453,7 +453,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (!task_ids?.length) return okResult({ results: [] });
       const now = new Date();
       const plannedAt = unplan ? null : new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-      const updates = task_ids.map(id => ({ taskId: id, data: { plannedAt } }));
+      const updates = task_ids.map(id => ({ taskId: id, data: { dueWithTime: plannedAt } }));
       const res = await sendCommand(dirs, 'bulkUpdateTasks', { updates });
       if (!res.success) return errorResult(res.error ?? 'Failed to plan tasks');
       return okResult(res.result);

--- a/tests/unit/resources/resources.test.ts
+++ b/tests/unit/resources/resources.test.ts
@@ -86,8 +86,8 @@ describe('MCP Resources', () => {
       const now = new Date();
       const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
       mockSend.mockResolvedValueOnce(mockResponse([
-        { id: '1', title: 'Today task', projectId: 'p1', tagIds: [], plannedAt: startOfToday + 3600000, timeEstimate: 0, timeSpent: 0 },
-        { id: '2', title: 'No plan', projectId: 'p1', tagIds: [], plannedAt: null, timeEstimate: 0, timeSpent: 0 },
+        { id: '1', title: 'Today task', projectId: 'p1', tagIds: [], dueWithTime: startOfToday + 3600000, timeEstimate: 0, timeSpent: 0 },
+        { id: '2', title: 'No plan', projectId: 'p1', tagIds: [], dueWithTime: null, timeEstimate: 0, timeSpent: 0 },
       ]));
       const result = await registeredResources['sp-tasks-today'](new URL('sp://tasks/today'));
       const data = JSON.parse(result.contents[0].text);

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -84,49 +84,49 @@ describe('task tool logic', () => {
       }));
     });
 
-    it('sends updateTask with dueDay and plannedAt together', async () => {
+    it('sends updateTask with dueDay and dueWithTime together', async () => {
       mockSend.mockResolvedValueOnce(mockResponse({}));
       await sendCommand(dirs, 'updateTask', {
         taskId: 'task-1',
-        data: { dueDay: '2026-04-20', plannedAt: 1745150400000 },
+        data: { dueDay: '2026-04-20', dueWithTime: 1745150400000 },
       });
       expect(mockSend).toHaveBeenCalledWith(dirs, 'updateTask', expect.objectContaining({
         taskId: 'task-1',
-        data: expect.objectContaining({ dueDay: '2026-04-20', plannedAt: expect.any(Number) }),
+        data: expect.objectContaining({ dueDay: '2026-04-20', dueWithTime: expect.any(Number) }),
       }));
     });
 
-    it('clears dueDay and plannedAt together', async () => {
+    it('clears dueDay and dueWithTime together', async () => {
       mockSend.mockResolvedValueOnce(mockResponse({}));
       await sendCommand(dirs, 'updateTask', {
         taskId: 'task-1',
-        data: { dueDay: null, plannedAt: null },
+        data: { dueDay: null, dueWithTime: null },
       });
       expect(mockSend).toHaveBeenCalledWith(dirs, 'updateTask', expect.objectContaining({
         taskId: 'task-1',
-        data: { dueDay: null, plannedAt: null },
+        data: { dueDay: null, dueWithTime: null },
       }));
     });
 
-    it('sets plannedAt independently without dueDay', async () => {
+    it('sets dueWithTime independently without dueDay', async () => {
       mockSend.mockResolvedValueOnce(mockResponse({}));
       const startOfToday = new Date();
       startOfToday.setHours(0, 0, 0, 0);
       await sendCommand(dirs, 'updateTask', {
         taskId: 'task-1',
-        data: { plannedAt: startOfToday.getTime() },
+        data: { dueWithTime: startOfToday.getTime() },
       });
       expect(mockSend).toHaveBeenCalledWith(dirs, 'updateTask', expect.objectContaining({
         taskId: 'task-1',
-        data: expect.objectContaining({ plannedAt: startOfToday.getTime() }),
+        data: expect.objectContaining({ dueWithTime: startOfToday.getTime() }),
       }));
     });
 
-    it('clears plannedAt without touching dueDay', async () => {
+    it('clears dueWithTime without touching dueDay', async () => {
       mockSend.mockResolvedValueOnce(mockResponse({}));
-      await sendCommand(dirs, 'updateTask', { taskId: 'task-1', data: { plannedAt: null } });
+      await sendCommand(dirs, 'updateTask', { taskId: 'task-1', data: { dueWithTime: null } });
       expect(mockSend).toHaveBeenCalledWith(dirs, 'updateTask', expect.objectContaining({
-        data: { plannedAt: null },
+        data: { dueWithTime: null },
       }));
     });
   });
@@ -307,15 +307,16 @@ describe('task tool logic', () => {
     const now = new Date();
     const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
     const tasks = [
-      { id: '1', title: 'Planned today', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: null, timeEstimate: 0, timeSpent: 0, plannedAt: startOfToday + 3600000 },
-      { id: '2', title: 'Planned yesterday', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: null, timeEstimate: 0, timeSpent: 0, plannedAt: startOfToday - 86400000 },
+      { id: '1', title: 'Planned today', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: startOfToday + 3600000, timeEstimate: 0, timeSpent: 0, plannedAt: null },
+      { id: '2', title: 'Planned yesterday', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: startOfToday - 86400000, timeEstimate: 0, timeSpent: 0, plannedAt: null },
       { id: '3', title: 'Not planned', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: null, timeEstimate: 0, timeSpent: 0, plannedAt: null },
-      { id: '4', title: 'Subtask planned today', isDone: false, projectId: null, tagIds: [], parentId: 'p-1', dueDay: null, dueWithTime: null, timeEstimate: 0, timeSpent: 0, plannedAt: startOfToday + 1000 },
+      { id: '4', title: 'Subtask planned today', isDone: false, projectId: null, tagIds: [], parentId: 'p-1', dueDay: null, dueWithTime: startOfToday + 1000, timeEstimate: 0, timeSpent: 0, plannedAt: null },
+      { id: '5', title: 'Legacy plannedAt fallback', isDone: false, projectId: 'p1', tagIds: [], parentId: null, dueDay: null, dueWithTime: null, timeEstimate: 0, timeSpent: 0, plannedAt: startOfToday + 2000 },
     ];
 
     it('returns only tasks planned for today', () => {
       const result = applyTriageFilters(tasks, { plannedForToday: true });
-      expect(result.map(t => t.id)).toEqual(['1', '4']);
+      expect(result.map(t => t.id)).toEqual(['1', '4', '5']);
     });
 
     it('excludes tasks planned yesterday', () => {
@@ -323,14 +324,19 @@ describe('task tool logic', () => {
       expect(result.find(t => t.id === '2')).toBeUndefined();
     });
 
-    it('excludes tasks with null plannedAt', () => {
+    it('excludes tasks with no scheduled time', () => {
       const result = applyTriageFilters(tasks, { plannedForToday: true });
       expect(result.find(t => t.id === '3')).toBeUndefined();
     });
 
+    it('matches tasks with legacy plannedAt as fallback', () => {
+      const result = applyTriageFilters(tasks, { plannedForToday: true });
+      expect(result.find(t => t.id === '5')).toBeDefined();
+    });
+
     it('combines with parents_only (AND logic)', () => {
       const result = applyTriageFilters(tasks, { plannedForToday: true, parentsOnly: true });
-      expect(result.map(t => t.id)).toEqual(['1']);
+      expect(result.map(t => t.id)).toEqual(['1', '5']);
     });
   });
 
@@ -535,20 +541,20 @@ describe('task tool logic', () => {
 
   // 006: plan_tasks_for_today via sendCommand
   describe('plan_tasks_for_today via sendCommand', () => {
-    it('sends bulkUpdateTasks with plannedAt for each task', async () => {
+    it('sends bulkUpdateTasks with dueWithTime for each task', async () => {
       const results = { results: [{ id: 't1', success: true }, { id: 't2', success: true }] };
       mockSend.mockResolvedValueOnce(mockResponse(results));
       const res = await sendCommand(dirs, 'bulkUpdateTasks', {
-        updates: [{ taskId: 't1', data: { plannedAt: 1745884800000 } }, { taskId: 't2', data: { plannedAt: 1745884800000 } }],
+        updates: [{ taskId: 't1', data: { dueWithTime: 1745884800000 } }, { taskId: 't2', data: { dueWithTime: 1745884800000 } }],
       });
       expect(res.success).toBe(true);
       expect((res.result as any).results).toHaveLength(2);
     });
 
-    it('sends null plannedAt when unplanning', async () => {
+    it('sends null dueWithTime when unplanning', async () => {
       mockSend.mockResolvedValueOnce(mockResponse({ results: [{ id: 't1', success: true }] }));
-      await sendCommand(dirs, 'bulkUpdateTasks', { updates: [{ taskId: 't1', data: { plannedAt: null } }] });
-      expect(mockSend).toHaveBeenCalledWith(dirs, 'bulkUpdateTasks', { updates: [{ taskId: 't1', data: { plannedAt: null } }] });
+      await sendCommand(dirs, 'bulkUpdateTasks', { updates: [{ taskId: 't1', data: { dueWithTime: null } }] });
+      expect(mockSend).toHaveBeenCalledWith(dirs, 'bulkUpdateTasks', { updates: [{ taskId: 't1', data: { dueWithTime: null } }] });
     });
   });
 


### PR DESCRIPTION
## Problem

Scheduling tasks via the MCP bridge does not work with current Super Productivity versions. Tasks get a `plannedAt` timestamp, but SP migrated to `dueWithTime` long ago (Migration 4: `task.dueWithTime = task.plannedAt; delete task.plannedAt`). The app UI reads only `dueWithTime`, so:

- `plan_tasks_for_today` — task never appears in Today or Schedule views
- `update_task` with `planned_at` — the schedule time is silently dropped
- `get_tasks(planned_for_today: true)` — always returns nothing, because the filter reads the legacy `plannedAt` field (app v1.17.x has ~710 `dueWithTime` references vs ~11 `plannedAt` references)

## Fix

Write and read SP's current scheduling field (`dueWithTime`) everywhere, keeping `plannedAt` as a read-fallback for older app versions:

- `src/tools/tasks.ts`
  - `update_task`: map `planned_at` → `data.dueWithTime`
  - `create_task`: clear `dueWithTime` (not `plannedAt`) on plain tasks to prevent auto-scheduling
  - `plan_tasks_for_today` / `bulk_update_tasks`: set `dueWithTime`
  - `planned_for_today` filter: `t.dueWithTime ?? t.plannedAt`
- `src/resources/index.ts` — `shapeTask` serializes `dueWithTime ?? plannedAt`
- `plugin/plugin.js` — `updateTask` preserves `dueWithTime` when `dueDay` changes (SP auto-moves it otherwise); `addTask` cleanup clears `dueWithTime`
- tests updated to assert the new payloads, including a legacy-`plannedAt` fallback case
- README Known Limitations entry updated

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` — all pass (112 tests)
- Manually verified against Super Productivity 1.17.4 (Flatpak): patched bridge writes `dueWithTime`; tasks scheduled via `plan_tasks_for_today` appear in the Schedule view and are returned by `planned_for_today`