### PR TITLE
Add log_time action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,26 @@
 
 ```bash
 npm run build        # compile MCP server (tsup) + zip plugin → dist/plugin.zip
+npm run build:server # tsup only — dist/index.js
+npm run build:plugin # inline the pane into index.html, then zip → dist/plugin.zip
 npm run dev          # watch mode
 npm test             # vitest run
 npm run test:watch   # vitest watch
 npm run typecheck    # tsc --noEmit (use this, not npx tsc — tsc not in PATH)
 npm run lint         # eslint src/
+```
+
+A Makefile wraps these; the npm scripts stay the source of truth (CI and
+`prepublishOnly` call them directly). What it adds is dependency tracking —
+`dist/index.js` and `dist/plugin.zip` are real file targets, so an unchanged
+tree rebuilds nothing.
+
+```bash
+make                 # build both artifacts
+make verify          # typecheck + lint + test — the pre-commit gate
+make mcp-add         # register with Claude Code (SCOPE=local to override)
+make mcp-remove
+make clean
 ```
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+# Super-Productivity-MCP
+#
+# A thin wrapper over the npm scripts, not a replacement for them.
+# .github/workflows/ci.yml and prepublishOnly both invoke the npm scripts
+# directly, so reimplementing the build here would let the two drift and stop
+# CI from testing what you run locally. Every target below shells out.
+#
+# What make adds is dependency tracking: dist/index.js and dist/plugin.zip are
+# real file targets, so an unchanged tree rebuilds nothing.
+
+SHELL := /bin/bash
+
+# Overridable: SCOPE=local make mcp-add
+MCP_NAME ?= super-productivity
+SCOPE    ?= user
+
+SERVER_SRC := $(shell find src -type f -name '*.ts' 2>/dev/null)
+PLUGIN_SRC := $(wildcard plugin/*) scripts/build-plugin.mjs
+
+.DEFAULT_GOAL := build
+.PHONY: build install test lint typecheck verify mcp-add mcp-remove clean
+
+## Build both artifacts
+build: dist/index.js dist/plugin.zip
+
+## MCP server bundle
+dist/index.js: $(SERVER_SRC) tsup.config.ts tsconfig.json | node_modules
+	npm run build:server
+
+## SP plugin bundle. The pane's JS is inlined into index.html by the build
+## script — SP serves only index.html to the iframe, so a separate .js file
+## in the zip is never fetched.
+dist/plugin.zip: $(PLUGIN_SRC) | node_modules
+	npm run build:plugin
+
+## npm ci is driven by the lockfile; touch so make sees the dir as up to date
+node_modules: package-lock.json
+	npm ci
+	@touch node_modules
+
+install: node_modules
+
+test lint typecheck: | node_modules
+	npm run $@
+
+## The pre-commit gate
+verify: typecheck lint test
+
+## Register the server with Claude Code, pointing at this checkout's build
+mcp-add: dist/index.js
+	claude mcp add -s $(SCOPE) $(MCP_NAME) -- node $(CURDIR)/dist/index.js
+	@echo
+	@echo "Registered '$(MCP_NAME)' ($(SCOPE) scope) -> $(CURDIR)/dist/index.js"
+	@echo
+	@echo "Claude Code loads MCP servers at startup, and a running server keeps"
+	@echo "the code it was spawned with. After this — and after every rebuild —"
+	@echo "reconnect it with /mcp, or restart the session (claude --continue)."
+	@echo "Super Productivity also needs dist/plugin.zip uploaded in"
+	@echo "Settings -> Plugins, with Node execution allowed."
+
+mcp-remove:
+	claude mcp remove -s $(SCOPE) $(MCP_NAME)
+
+clean:
+	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 | `get_tasks` | List tasks — filter by project, tag, done, archived, search (title+notes), `parents_only`, `overdue`, `unscheduled`, `planned_for_today`, `recurring_only`, `fields` |
 | `update_task` | Update title, notes, done state, due date, deadline, `planned_at`, time estimate, tags |
 | `complete_task` | Mark a task as complete |
-| `delete_task` | Permanently delete a task (parent deletes subtasks too) |
+| `delete_task` | Permanently delete a task (parent deletes subtasks too). Archived tasks can't be deleted — SP's plugin API is read-only for the archive |
 | `start_task` | Start the time tracker on a task |
 | `stop_task` | Stop the currently running time tracker |
 | `log_time` | Log time spent on a task — one day, or several at once via `entries` for backfill. Adds to each day's tracked time, or overwrites with `mode: "set"` |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 
 Habit tools (`create_habit`, `get_habits`, `update_habit`, `check_habit`, `set_habit_value`, `delete_habit`) require a Super Productivity build newer than the `14.0.0` minimum above — on older builds they return a clear "requires a newer version" error instead of failing silently.
 
+## Tool Call Timeline
+
+The plugin adds a **MCP Bridge** pane to Super Productivity's menu listing what
+the assistant has done — one row per tool call with the time, tool name,
+duration, and whether it succeeded. Click a row to see the arguments it was
+called with and the result it returned; failures show the error message.
+
+The server writes each call to `tool-calls.jsonl` in the same data directory it
+uses for IPC (`debug_directories` shows the path). The log keeps the most recent
+500 calls and is created mode 0600. Individual arguments or results over 8KB are
+replaced by a marker recording how many bytes were elided, so a `get_tasks` over
+a large task list doesn't copy your database into a flat file.
+
+Recording is best-effort: if the log can't be written, the tool call still
+succeeds and returns normally.
+
 ## SP Short Syntax
 
 Include these in task titles and they are parsed automatically:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 | `delete_task` | Permanently delete a task (parent deletes subtasks too) |
 | `start_task` | Start the time tracker on a task |
 | `stop_task` | Stop the currently running time tracker |
+| `log_time` | Log time spent on a task for a given day — adds to that day's tracked time, or overwrites it with `mode: "set"` |
 | `get_current_task` | Get the currently tracked task (null if none) |
 | `plan_tasks_for_today` | Batch plan/unplan tasks for today ⚠️ [limited](#known-limitations) |
 | `bulk_complete_tasks` | Mark multiple tasks complete in one operation |

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 | `create_task` | Create a task (supports SP short syntax) |
 | `create_task_with_subtasks` | Create a parent task + subtasks in one operation |
 | `get_tasks` | List tasks — filter by project, tag, done, archived, search (title+notes), `parents_only`, `overdue`, `unscheduled`, `planned_for_today`, `recurring_only`, `fields` |
-| `update_task` | Update title, notes, done state, due date, deadline, `planned_at`, time, tags |
+| `update_task` | Update title, notes, done state, due date, deadline, `planned_at`, time estimate, tags |
 | `complete_task` | Mark a task as complete |
 | `delete_task` | Permanently delete a task (parent deletes subtasks too) |
 | `start_task` | Start the time tracker on a task |
 | `stop_task` | Stop the currently running time tracker |
-| `log_time` | Log time spent on a task for a given day — adds to that day's tracked time, or overwrites it with `mode: "set"` |
+| `log_time` | Log time spent on a task — one day, or several at once via `entries` for backfill. Adds to each day's tracked time, or overwrites with `mode: "set"` |
 | `get_current_task` | Get the currently tracked task (null if none) |
 | `plan_tasks_for_today` | Batch plan/unplan tasks for today ⚠️ [limited](#known-limitations) |
 | `bulk_complete_tasks` | Mark multiple tasks complete in one operation |
@@ -171,6 +171,40 @@ The plugin to upload to Super Productivity is at `dist/plugin.zip` after `npm ru
 | `debug_directories` | Show resolved data directory paths |
 
 Habit tools (`create_habit`, `get_habits`, `update_habit`, `check_habit`, `set_habit_value`, `delete_habit`) require a Super Productivity build newer than the `14.0.0` minimum above — on older builds they return a clear "requires a newer version" error instead of failing silently.
+
+## Time Tracking
+
+Super Productivity stores time spent as a **per-day worklog** (`timeSpentOnDay`,
+a map of `YYYY-MM-DD` to milliseconds). The task's total, `timeSpent`, is always
+derived from it — SP recomputes the total on every write, and a parent task's
+time is the aggregate of its subtasks.
+
+This server follows that model:
+
+- **Reading** — both fields are available on `get_tasks`, including via field
+  selection: `fields: ["timeSpent", "timeSpentOnDay"]`. They also appear in the
+  `sp://tasks` resource summary. `get_worklog` aggregates the map across tasks
+  by day, project, and tag.
+- **Writing** — through `log_time` only, which writes the day map and recomputes
+  the total the way SP does. `update_task` and `bulk_update_tasks` deliberately
+  cannot set `timeSpent`: writing a total that no worklog accounts for produces a
+  task SP's own model cannot represent, and SP silently discards it at the next
+  write to that task's time.
+
+```jsonc
+// one day
+{ "task_id": "abc", "duration": "1h30m" }               // defaults to today
+// several days, e.g. backfilling a week
+{ "task_id": "abc", "entries": [
+    { "date": "2026-08-30", "duration": "2h" },
+    { "date": "2026-08-31", "duration": "45m" }
+] }
+```
+
+If a task's stored total disagreed with its worklog before the write — which
+happens with data imported from other tools — `log_time` recomputes from the
+worklog and reports the old value as `previousTimeSpent`, so the correction is
+visible rather than silent.
 
 ## Tool Call Timeline
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-productivity-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "super-productivity-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "super-productivity-mcp",
   "version": "1.7.0",
-  "description": "MCP server for Super Productivity — manage tasks, projects, and tags via AI assistants",
+  "description": "MCP server for Super Productivity \u2014 manage tasks, projects, and tags via AI assistants",
   "main": "dist/index.js",
   "bin": {
     "super-productivity-mcp": "dist/index.js"
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup && npm run build:plugin",
+    "build:server": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "prepublishOnly": "npm run build",
-    "build:plugin": "cd plugin && zip -r ../dist/plugin.zip manifest.json plugin.js dashboard.js index.html icon.svg"
+    "build:plugin": "node scripts/build-plugin.mjs"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-productivity-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MCP server for Super Productivity — manage tasks, projects, and tags via AI assistants",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "prepublishOnly": "npm run build",
-    "build:plugin": "cd plugin && zip -r ../dist/plugin.zip manifest.json plugin.js index.html icon.svg"
+    "build:plugin": "cd plugin && zip -r ../dist/plugin.zip manifest.json plugin.js dashboard.js index.html icon.svg"
   },
   "files": [
     "dist",

--- a/plugin/dashboard.js
+++ b/plugin/dashboard.js
@@ -1,0 +1,230 @@
+// Tool call timeline — the plugin's iframe pane.
+//
+// SP injects a filtered PluginAPI into index.html and proxies executeNodeScript
+// through the host bridge whenever nodeExecution is granted, so this reads the
+// log the MCP server writes without any postMessage bridge back to plugin.js.
+
+var REFRESH_MS = 2000;
+var LOG_FILENAME = 'tool-calls.jsonl';
+
+// ---------------------------------------------------------------- pure helpers
+
+/**
+ * Parse the JSONL log into entries, newest first. A half-written final line is
+ * expected — the server appends while the pane reads — so unparseable lines are
+ * skipped rather than failing the render.
+ */
+function parseLog(text) {
+  if (!text || typeof text !== 'string') return [];
+  var entries = [];
+  var lines = text.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim();
+    if (!line) continue;
+    try {
+      var parsed = JSON.parse(line);
+      // Guard against valid JSON that isn't an entry ("null", "42").
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) entries.push(parsed);
+    } catch (e) { /* partial or corrupt line — skip it */ }
+  }
+  return entries.reverse();
+}
+
+function formatDuration(ms) {
+  if (typeof ms !== 'number' || isNaN(ms)) return '—';
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  return Math.floor(ms / 60000) + 'm ' + Math.round((ms % 60000) / 1000) + 's';
+}
+
+/**
+ * Identity of an entry across refreshes. The log is append-only and a tool call
+ * is unique by the instant it started plus its name, so this survives new
+ * entries arriving above it.
+ */
+function entryKey(entry) {
+  return (entry && entry.ts) + '|' + (entry && entry.tool);
+}
+
+/** Whether the log actually changed since the last poll. */
+function hasChanged(previous, next) {
+  return previous !== next;
+}
+
+function formatTime(ts) {
+  if (typeof ts !== 'number' || isNaN(ts)) return '—';
+  var d = new Date(ts);
+  var pad = function (n) { return String(n).padStart(2, '0'); };
+  return pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    parseLog: parseLog, formatDuration: formatDuration, formatTime: formatTime,
+    entryKey: entryKey, hasChanged: hasChanged,
+  };
+}
+
+// ---------------------------------------------------------------- reading the log
+
+// Probes the same candidates plugin.js resolves, but only looks for an existing
+// log — the pane must never create directories or decide where the IPC dir goes.
+var READ_LOG_SCRIPT = [
+  "const fs = require('fs');",
+  "const path = require('path');",
+  "const os = require('os');",
+  "const home = os.homedir();",
+  "const APP = 'super-productivity-mcp';",
+  "let candidates;",
+  "if (os.platform() === 'darwin') {",
+  "  candidates = [",
+  "    path.join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP),",
+  "    path.join(home, 'Library', 'Application Support', APP)",
+  "  ];",
+  "} else if (os.platform() === 'win32') {",
+  "  const appData = (typeof process !== 'undefined' && process.env && process.env.APPDATA) || path.join(home, 'AppData', 'Roaming');",
+  "  candidates = [path.join(appData, APP)];",
+  "} else {",
+  "  const xdgData = (typeof process !== 'undefined' && process.env && process.env.XDG_DATA_HOME) || path.join(home, '.local', 'share');",
+  "  candidates = [",
+  "    path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'data', APP),",
+  "    path.join(home, '.var', 'app', 'com.super_productivity.SuperProductivity', 'config', APP),",
+  "    path.join(xdgData, APP),",
+  "    path.join(home, 'snap', 'superproductivity', 'common', '.local', 'share', APP),",
+  "    path.join(home, 'snap', 'superproductivity', 'current', '.local', 'share', APP),",
+  "    path.join('/tmp', APP)",
+  "  ];",
+  "}",
+  "for (const dir of candidates) {",
+  "  const file = path.join(dir, '" + LOG_FILENAME + "');",
+  "  if (fs.existsSync(file)) return { text: fs.readFileSync(file, 'utf-8'), path: file };",
+  "}",
+  "return { text: '', path: null };",
+].join('\n');
+
+function unwrap(result) {
+  return result && result.success && result.result && typeof result.result === 'object' ? result.result : result;
+}
+
+async function readLog() {
+  if (typeof PluginAPI === 'undefined' || typeof PluginAPI.executeNodeScript !== 'function') {
+    throw new Error('This pane needs Node execution. Enable it for the plugin in Super Productivity settings.');
+  }
+  var res = unwrap(await PluginAPI.executeNodeScript({ script: READ_LOG_SCRIPT, timeout: 5000 }));
+  if (!res || res.success === false) throw new Error((res && res.error) || 'Could not read the log');
+  return (res.result && res.result.text) || res.text || '';
+}
+
+// ---------------------------------------------------------------- rendering
+
+function statusOf(entry) {
+  return entry.ok === false ? 'err' : 'ok';
+}
+
+function payloadText(value) {
+  if (value === undefined) return null;
+  if (value && value._truncated) {
+    // Be honest that this isn't the whole thing rather than showing a clipped
+    // object as if it were complete.
+    return '// truncated — ' + value.bytes + ' bytes not recorded\n' + (value.preview || '');
+  }
+  try { return JSON.stringify(value, null, 2); } catch (e) { return String(value); }
+}
+
+function renderEntry(entry, expanded) {
+  var key = entryKey(entry);
+  var row = document.createElement('div');
+  row.className = 'entry ' + statusOf(entry);
+
+  var head = document.createElement('button');
+  head.className = 'head';
+  head.setAttribute('aria-expanded', 'false');
+  head.innerHTML =
+    '<span class="time">' + formatTime(entry.ts) + '</span>' +
+    '<span class="tool"></span>' +
+    '<span class="dur">' + formatDuration(entry.ms) + '</span>' +
+    '<span class="badge">' + (entry.ok === false ? 'error' : 'ok') + '</span>';
+  // Tool names come from our own registry, but set as text regardless — the log
+  // is a file on disk and nothing here should be able to inject markup.
+  head.querySelector('.tool').textContent = entry.tool || '(unknown)';
+
+  var body = document.createElement('div');
+  body.className = 'body';
+  body.hidden = !expanded.has(key);
+  head.setAttribute('aria-expanded', String(!body.hidden));
+
+  if (entry.error) {
+    var err = document.createElement('p');
+    err.className = 'err-msg';
+    err.textContent = entry.error;
+    body.appendChild(err);
+  }
+  [['arguments', entry.args], ['result', entry.result]].forEach(function (pair) {
+    var text = payloadText(pair[1]);
+    if (text === null) return;
+    var h = document.createElement('h4');
+    h.textContent = pair[0];
+    var pre = document.createElement('pre');
+    pre.textContent = text;
+    body.appendChild(h);
+    body.appendChild(pre);
+  });
+
+  head.addEventListener('click', function () {
+    body.hidden = !body.hidden;
+    head.setAttribute('aria-expanded', String(!body.hidden));
+    if (body.hidden) expanded.delete(key); else expanded.add(key);
+  });
+
+  row.appendChild(head);
+  row.appendChild(body);
+  return row;
+}
+
+function render(entries, root, status, expanded) {
+  root.textContent = '';
+  if (!entries.length) {
+    var empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = 'No tool calls recorded yet. Ask your assistant to do something in Super Productivity.';
+    root.appendChild(empty);
+    status.textContent = '';
+    return;
+  }
+  entries.forEach(function (entry) { root.appendChild(renderEntry(entry, expanded)); });
+  var failed = entries.filter(function (e) { return e.ok === false; }).length;
+  status.textContent = entries.length + ' call' + (entries.length === 1 ? '' : 's') +
+    (failed ? ' · ' + failed + ' failed' : '');
+}
+
+// ---------------------------------------------------------------- bootstrap
+
+async function refresh(root, status, state) {
+  try {
+    var text = await readLog();
+    // Skipping an unchanged render is what keeps an expanded row open: the poll
+    // runs every 2s and a rebuilt DOM would collapse whatever the user opened.
+    if (!hasChanged(state.lastText, text)) return;
+    state.lastText = text;
+    render(parseLog(text), root, status, state.expanded);
+  } catch (err) {
+    root.textContent = '';
+    var p = document.createElement('p');
+    p.className = 'empty error';
+    p.textContent = err.message || String(err);
+    root.appendChild(p);
+    status.textContent = '';
+    state.lastText = null;
+  }
+}
+
+// Guarded so importing this file in the test runner doesn't try to boot a UI.
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', function () {
+    var root = document.getElementById('entries');
+    var status = document.getElementById('status');
+    var state = { lastText: null, expanded: new Set() };
+    refresh(root, status, state);
+    setInterval(function () { refresh(root, status, state); }, REFRESH_MS);
+  });
+}

--- a/plugin/dashboard.js
+++ b/plugin/dashboard.js
@@ -220,11 +220,20 @@ async function refresh(root, status, state) {
 
 // Guarded so importing this file in the test runner doesn't try to boot a UI.
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
-  window.addEventListener('DOMContentLoaded', function () {
+  var start = function () {
     var root = document.getElementById('entries');
     var status = document.getElementById('status');
     var state = { lastText: null, expanded: new Set() };
     refresh(root, status, state);
     setInterval(function () { refresh(root, status, state); }, REFRESH_MS);
-  });
+  };
+  // SP injects index.html via srcdoc, and whether DOMContentLoaded is still
+  // ahead of this script under srcdoc isn't documented. Waiting for an event
+  // that already fired would leave the pane blank forever, so branch on
+  // readyState rather than trusting the event.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 }

--- a/plugin/index.html
+++ b/plugin/index.html
@@ -1,3 +1,65 @@
 <!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>MCP Bridge</title></head>
-<body><script src="plugin.js"></script></body></html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MCP Tool Calls</title>
+<style>
+  :root {
+    --bg: #fff; --fg: #1a1a1a; --muted: #6b7280; --line: #e5e7eb;
+    --ok: #059669; --err: #dc2626; --err-bg: #fef2f2; --code-bg: #f6f7f9;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #1e1e1e; --fg: #e6e6e6; --muted: #9ca3af; --line: #333;
+      --ok: #34d399; --err: #f87171; --err-bg: #2a1416; --code-bg: #262626;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 12px; background: var(--bg); color: var(--fg);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 10px; }
+  h1 { font-size: 15px; font-weight: 600; margin: 0; }
+  #status { color: var(--muted); font-size: 12px; }
+  .entry { border-bottom: 1px solid var(--line); }
+  .head {
+    display: grid; grid-template-columns: 76px 1fr auto 56px;
+    gap: 10px; align-items: center; width: 100%;
+    padding: 8px 4px; background: none; border: 0; cursor: pointer;
+    color: inherit; font: inherit; text-align: left;
+  }
+  .head:hover { background: var(--code-bg); }
+  .time, .dur { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--muted); }
+  .dur { text-align: right; }
+  .tool { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .badge { font-size: 11px; text-align: right; color: var(--ok); }
+  .err .badge { color: var(--err); }
+  .err .tool { color: var(--err); }
+  .body { padding: 4px 4px 12px; }
+  .body h4 { margin: 8px 0 4px; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  .err-msg { margin: 4px 0; padding: 8px; border-radius: 4px; background: var(--err-bg); color: var(--err); }
+  pre {
+    margin: 0; padding: 8px; border-radius: 4px; background: var(--code-bg);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
+    overflow-x: auto; white-space: pre; max-height: 320px;
+  }
+  .empty { color: var(--muted); padding: 24px 4px; text-align: center; }
+  .empty.error { color: var(--err); }
+</style>
+</head>
+<body>
+  <header>
+    <h1>Tool calls</h1>
+    <span id="status"></span>
+  </header>
+  <main id="entries"></main>
+  <!--
+    Loads dashboard.js only. plugin.js is the host-side background script and
+    runs its own command-processing loop; loading it here as well would start a
+    second loop inside the iframe, with both racing to claim command files.
+  -->
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -6,7 +6,8 @@
   "manifestVersion": 1,
   "minSupVersion": "14.0.0",
   "permissions": [
-    "nodeExecution"
+    "nodeExecution",
+    "showIndexHtmlAsView"
   ],
   "hooks": [
     "taskUpdate",
@@ -15,7 +16,7 @@
     "currentTaskChange"
   ],
   "iFrame": true,
-  "isSkipMenuEntry": true,
+  "isSkipMenuEntry": false,
   "icon": "icon.svg",
   "categories": [
     "integration",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "super-productivity-mcp",
   "name": "SP MCP Server",
   "description": "MCP server bridge for AI assistant integration with Super Productivity",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "manifestVersion": 1,
   "minSupVersion": "14.0.0",
   "permissions": [

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -62,6 +62,22 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = { parseAtDateSyntax, executeCommand };
 }
 
+// Set one day's entry in a timeSpentOnDay map and recompute the derived total.
+// SP stores timeSpent as the sum of the per-day map, and PluginAPI exposes no
+// addTimeSpent action to keep them in sync — writing timeSpentOnDay through the
+// generic updateTask means we own that recomputation. A day that lands on zero is
+// removed rather than kept, so get_worklog never reports a day with no work on it.
+function applyDayTime(timeSpentOnDay, day, ms) {
+  const map = Object.assign({}, timeSpentOnDay || {});
+  if (ms > 0) {
+    map[day] = ms;
+  } else {
+    delete map[day];
+  }
+  const timeSpent = Object.keys(map).reduce((sum, key) => sum + map[key], 0);
+  return { timeSpentOnDay: map, timeSpent };
+}
+
 // Local YYYY-MM-DD for "today", matching how SP's own getDbDateStr keys countOnDay
 // (local calendar day, not UTC — avoids shifting a day in positive timezones).
 function todayLocalDateStr() {
@@ -465,6 +481,38 @@ async function executeCommand(command) {
         }
         // Idempotent — no error if nothing is being tracked
         result = null;
+        break;
+      }
+      case 'logTime': {
+        // PluginAPI has no addTimeSpent equivalent, and updateTask() silently no-ops on
+        // an unknown id (the quirk bulkUpdateTasks and startTask guard against), so the
+        // task has to be looked up before anything is written.
+        const logData = command.data || {};
+        const day = logData.date;
+        const allTasksForLog = await PluginAPI.getTasks();
+        const taskForLog = allTasksForLog.find(t => t.id === command.taskId);
+        if (!taskForLog) {
+          return { success: false, error: `Task not found: ${command.taskId}`, timestamp: Date.now() };
+        }
+
+        const previous = (taskForLog.timeSpentOnDay || {})[day] || 0;
+        const next = logData.mode === 'set' ? logData.durationMs : previous + logData.durationMs;
+        const updated = applyDayTime(taskForLog.timeSpentOnDay, day, next);
+        await PluginAPI.updateTask(command.taskId, updated);
+
+        // SP treats a parent's tracked time as the aggregate of its subtasks, so the same
+        // delta has to land on the parent — otherwise the parent and get_worklog's project
+        // totals drift apart from the subtask that actually recorded the work.
+        const delta = next - previous;
+        if (taskForLog.parentId && delta !== 0) {
+          const parentForLog = allTasksForLog.find(t => t.id === taskForLog.parentId);
+          if (parentForLog) {
+            const parentDay = Math.max(0, ((parentForLog.timeSpentOnDay || {})[day] || 0) + delta);
+            await PluginAPI.updateTask(parentForLog.id, applyDayTime(parentForLog.timeSpentOnDay, day, parentDay));
+          }
+        }
+
+        result = { taskId: command.taskId, date: day, timeSpentOnDay: updated.timeSpentOnDay, timeSpent: updated.timeSpent };
         break;
       }
       case 'deleteTask': {

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -1,5 +1,9 @@
 // MCP Bridge Plugin for Super Productivity
 const PROTOCOL_VERSION = 1;
+// Kept in step with plugin/manifest.json by tests/unit/plugin/version.test.ts —
+// this was a literal in the ping handler and check_connection reported 1.6.0
+// from a 1.7.0 plugin for a whole release.
+const PLUGIN_VERSION = '1.7.0';
 const POLL_INTERVAL_MS = 2000;
 let commandDir = null;
 let responseDir = null;
@@ -59,7 +63,7 @@ function parseAtDateSyntax(title, now = new Date()) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { parseAtDateSyntax, executeCommand };
+  module.exports = { parseAtDateSyntax, executeCommand, PLUGIN_VERSION };
 }
 
 // Set one day's entry in a timeSpentOnDay map and recompute the derived total.
@@ -644,7 +648,7 @@ async function executeCommand(command) {
         break;
       }
       case 'ping':
-        result = { pong: true, pluginVersion: '1.6.0', protocolVersion: PROTOCOL_VERSION };
+        result = { pong: true, pluginVersion: PLUGIN_VERSION, protocolVersion: PROTOCOL_VERSION };
         break;
       default:
         return { success: false, error: `Unknown command action: ${command.action}`, timestamp: Date.now() };

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -66,20 +66,26 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = { parseAtDateSyntax, executeCommand, PLUGIN_VERSION };
 }
 
-// Set one day's entry in a timeSpentOnDay map and recompute the derived total.
+// Set one or more days in a timeSpentOnDay map and recompute the derived total.
 // SP stores timeSpent as the sum of the per-day map, and PluginAPI exposes no
 // addTimeSpent action to keep them in sync — writing timeSpentOnDay through the
 // generic updateTask means we own that recomputation. A day that lands on zero is
 // removed rather than kept, so get_worklog never reports a day with no work on it.
-function applyDayTime(timeSpentOnDay, day, ms) {
+// The total is summed once at the end, not per day.
+function applyDayTimes(timeSpentOnDay, changes) {
   const map = Object.assign({}, timeSpentOnDay || {});
-  if (ms > 0) {
-    map[day] = ms;
-  } else {
-    delete map[day];
+  for (const change of changes) {
+    if (change.ms > 0) {
+      map[change.date] = change.ms;
+    } else {
+      delete map[change.date];
+    }
   }
-  const timeSpent = Object.keys(map).reduce((sum, key) => sum + map[key], 0);
-  return { timeSpentOnDay: map, timeSpent };
+  return { timeSpentOnDay: map, timeSpent: sumDayMap(map) };
+}
+
+function sumDayMap(map) {
+  return Object.keys(map || {}).reduce((sum, key) => sum + (map[key] || 0), 0);
 }
 
 // Local YYYY-MM-DD for "today", matching how SP's own getDbDateStr keys countOnDay
@@ -487,36 +493,60 @@ async function executeCommand(command) {
         result = null;
         break;
       }
-      case 'logTime': {
+      case 'logTime':
+      case 'logTimeEntries': {
         // PluginAPI has no addTimeSpent equivalent, and updateTask() silently no-ops on
         // an unknown id (the quirk bulkUpdateTasks and startTask guard against), so the
         // task has to be looked up before anything is written.
         const logData = command.data || {};
-        const day = logData.date;
+        // 'logTime' is the older single-day shape; normalise it so there is one code path.
+        const logEntries = logData.entries || [{ date: logData.date, durationMs: logData.durationMs }];
         const allTasksForLog = await PluginAPI.getTasks();
         const taskForLog = allTasksForLog.find(t => t.id === command.taskId);
         if (!taskForLog) {
           return { success: false, error: `Task not found: ${command.taskId}`, timestamp: Date.now() };
         }
 
-        const previous = (taskForLog.timeSpentOnDay || {})[day] || 0;
-        const next = logData.mode === 'set' ? logData.durationMs : previous + logData.durationMs;
-        const updated = applyDayTime(taskForLog.timeSpentOnDay, day, next);
+        const existingDays = taskForLog.timeSpentOnDay || {};
+        // SP always derives timeSpent from this map. A task whose stored total
+        // disagrees came from outside SP's reducers; recomputing corrects it, and
+        // the old value is reported back so the correction isn't silent.
+        const sumBefore = sumDayMap(existingDays);
+
+        const dayChanges = [];
+        const parentDeltas = [];
+        for (const entry of logEntries) {
+          const previous = existingDays[entry.date] || 0;
+          const next = logData.mode === 'set' ? entry.durationMs : previous + entry.durationMs;
+          dayChanges.push({ date: entry.date, ms: next });
+          if (next !== previous) parentDeltas.push({ date: entry.date, delta: next - previous });
+        }
+
+        const updated = applyDayTimes(existingDays, dayChanges);
         await PluginAPI.updateTask(command.taskId, updated);
 
         // SP treats a parent's tracked time as the aggregate of its subtasks, so the same
-        // delta has to land on the parent — otherwise the parent and get_worklog's project
-        // totals drift apart from the subtask that actually recorded the work.
-        const delta = next - previous;
-        if (taskForLog.parentId && delta !== 0) {
+        // deltas have to land on the parent — otherwise the parent and get_worklog's
+        // project totals drift from the subtask that actually recorded the work. All the
+        // affected days go in one update rather than one write per day.
+        if (taskForLog.parentId && parentDeltas.length) {
           const parentForLog = allTasksForLog.find(t => t.id === taskForLog.parentId);
           if (parentForLog) {
-            const parentDay = Math.max(0, ((parentForLog.timeSpentOnDay || {})[day] || 0) + delta);
-            await PluginAPI.updateTask(parentForLog.id, applyDayTime(parentForLog.timeSpentOnDay, day, parentDay));
+            const parentDays = parentForLog.timeSpentOnDay || {};
+            const parentChanges = parentDeltas.map(function (d) {
+              return { date: d.date, ms: Math.max(0, (parentDays[d.date] || 0) + d.delta) };
+            });
+            await PluginAPI.updateTask(parentForLog.id, applyDayTimes(parentDays, parentChanges));
           }
         }
 
-        result = { taskId: command.taskId, date: day, timeSpentOnDay: updated.timeSpentOnDay, timeSpent: updated.timeSpent };
+        result = {
+          taskId: command.taskId,
+          dates: logEntries.map(function (e) { return e.date; }),
+          timeSpentOnDay: updated.timeSpentOnDay,
+          timeSpent: updated.timeSpent,
+        };
+        if (taskForLog.timeSpent !== sumBefore) result.previousTimeSpent = taskForLog.timeSpent;
         break;
       }
       case 'deleteTask': {

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -104,6 +104,23 @@ function missingHabitApiError() {
   return missing.length ? 'Habit management requires a newer version of Super Productivity.' : null;
 }
 
+// PluginAPI exposes getArchivedTasks() for reading but nothing that removes from
+// the archive, so an archived task can be seen and never deleted. Reporting it as
+// "not found" is misleading for a task get_tasks will happily return — name the
+// real reason and say where deletion is possible. Probed defensively: older SP
+// builds may not expose the archive at all, and a failure here must not turn a
+// clear error into a thrown one.
+async function archivedTaskError(taskId) {
+  if (typeof PluginAPI.getArchivedTasks !== 'function') return null;
+  try {
+    const archived = await PluginAPI.getArchivedTasks();
+    if (!archived.some(t => t.id === taskId)) return null;
+    return `Task ${taskId} is archived. Archived tasks cannot be deleted through the plugin API — remove it from the archive in Super Productivity.`;
+  } catch (e) {
+    return null;
+  }
+}
+
 async function setupDirectories() {
   const result = await PluginAPI.executeNodeScript({
     script: `
@@ -553,7 +570,12 @@ async function executeCommand(command) {
         const allTasksForDelete = await PluginAPI.getTasks();
         const taskToDelete = allTasksForDelete.find(t => t.id === command.taskId);
         if (!taskToDelete) {
-          return { success: false, error: `Task not found: ${command.taskId}`, timestamp: Date.now() };
+          const archivedError = await archivedTaskError(command.taskId);
+          return {
+            success: false,
+            error: archivedError || `Task not found: ${command.taskId}`,
+            timestamp: Date.now(),
+          };
         }
         await PluginAPI.deleteTask(command.taskId);
         result = null;

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -1,0 +1,52 @@
+// Builds plugin.zip.
+//
+// SP serves only index.html to the plugin iframe (via srcdoc) — arbitrary extra
+// files from the ZIP are not served. A <script src="dashboard.js"> tag fetches
+// nothing and fails silently, so the pane's JS is inlined here at build time.
+// dashboard.js stays the source of truth: it's what the unit tests import.
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync, copyFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT_TAG = '<script src="dashboard.js"></script>';
+
+/** Inline the pane's JS into index.html, replacing the external script tag. */
+export function inlinePaneScript(html, js) {
+  if (!html.includes(SCRIPT_TAG)) {
+    throw new Error(`index.html has no ${SCRIPT_TAG} to replace — dashboard.js would not be loaded`);
+  }
+  const browserJs = js
+    // The CommonJS export block exists so vitest can import the pure helpers;
+    // in a browser `module` is undefined and the block is dead weight.
+    .replace(/if \(typeof module !== 'undefined' && module\.exports\) \{[\s\S]*?\n\}\n/, '')
+    // A literal </script> anywhere in the source would end the element early.
+    .replace(/<\/script>/g, '<\\/script>');
+  return html.replace(SCRIPT_TAG, `<script>\n${browserJs}\n</script>`);
+}
+
+function main() {
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+  const pluginDir = join(root, 'plugin');
+  const stage = join(root, 'dist', 'plugin-build');
+  const zipPath = join(root, 'dist', 'plugin.zip');
+
+  rmSync(stage, { recursive: true, force: true });
+  mkdirSync(stage, { recursive: true });
+
+  for (const file of ['manifest.json', 'plugin.js', 'icon.svg']) {
+    copyFileSync(join(pluginDir, file), join(stage, file));
+  }
+
+  const html = readFileSync(join(pluginDir, 'index.html'), 'utf-8');
+  const js = readFileSync(join(pluginDir, 'dashboard.js'), 'utf-8');
+  writeFileSync(join(stage, 'index.html'), inlinePaneScript(html, js));
+
+  if (existsSync(zipPath)) rmSync(zipPath);
+  execFileSync('zip', ['-r', '-q', zipPath, 'manifest.json', 'plugin.js', 'index.html', 'icon.svg'], { cwd: stage });
+  console.log(`Built ${zipPath} (pane script inlined, ${js.length} bytes)`);
+}
+
+// Only build when run directly — importing this from a test must not zip anything.
+if (process.argv[1] && process.argv[1].endsWith('build-plugin.mjs')) main();

--- a/specs/005-task-ergonomics/spec.md
+++ b/specs/005-task-ergonomics/spec.md
@@ -89,7 +89,7 @@ An AI agent breaks down a goal into a parent task + subtasks in one operation, a
 
 ### Valid Field Names for FR-001
 
-`id`, `title`, `isDone`, `projectId`, `parentId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`, `timeEstimate`, `timeSpent`, `notes`, `subTaskIds`, `doneOn`
+`id`, `title`, `isDone`, `projectId`, `parentId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`, `timeEstimate`, `timeSpent`, `notes`, `subTaskIds`, `doneOn`, `timeSpentOnDay`
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/006-tool-call-timeline/spec.md
+++ b/specs/006-tool-call-timeline/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Tool Call Timeline
+
+**Feature Branch**: `006-tool-call-timeline`
+**Created**: 2026-09-01
+**Status**: Draft
+**Input**: A dashboard pane inside Super Productivity showing a timeline of MCP tool calls — what ran, when, how long it took, whether it succeeded — with full arguments and results captured for inspection.
+
+## Context
+
+Nothing in the bridge records what the assistant did. `sendCommand` deletes each
+response file the moment it reads it (`src/ipc/command-sender.ts`), and
+`cleanStaleFiles` purges anything older than five minutes. There is no history to
+draw a timeline from, so this feature is two pieces: a recording mechanism, and a
+UI to read it.
+
+The plugin already declares `iFrame: true` in `plugin/manifest.json` but hides it
+with `isSkipMenuEntry: true`, and `plugin/index.html` is a three-line stub that
+renders nothing. That unused pane is where the UI goes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recording Tool Calls (Priority: P1)
+
+Every MCP tool invocation is appended to a durable log so there is something to
+display. Recording wraps tool registration rather than the IPC layer: the IPC
+layer only sees plugin actions (`getTasks`), and one tool can send several, so
+IPC-level records could not tell `get_worklog` from `log_time`.
+
+**Why this priority**: Without it there is no data. The pane is unbuildable.
+
+**Independent Test**: Invoke a registered tool against a fake server, then read
+the log file and verify one well-formed entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered tool, **When** its handler completes, **Then** one JSON line is appended containing `ts`, `tool`, `args`, `ms`, `ok`, and `result`
+2. **Given** a tool returns an error result, **When** it completes, **Then** the entry has `ok: false` and carries the error message
+3. **Given** a tool handler throws, **When** it is invoked, **Then** an entry is recorded with `ok: false` and the exception propagates to the client unchanged
+4. **Given** the log file cannot be written, **When** a tool is invoked, **Then** the tool returns its normal result and the caller sees no error
+5. **Given** a serialized payload exceeds the size cap, **When** it is recorded, **Then** it is replaced by a truncation marker stating the original byte count
+6. **Given** the log holds the maximum entries, **When** a new one is recorded, **Then** the oldest is dropped
+
+---
+
+### User Story 2 - Viewing the Timeline (Priority: P2)
+
+A pane inside Super Productivity lists recent tool calls newest-first, so the
+user can see what the assistant did to their tasks and why something failed.
+
+**Why this priority**: The visible deliverable, but it depends entirely on US1.
+
+**Independent Test**: Seed a log file with known entries, open the pane, verify
+the rows match.
+
+**Acceptance Scenarios**:
+
+1. **Given** entries exist, **When** the pane opens, **Then** each row shows local time, tool name, duration, and an ok/error badge, newest first
+2. **Given** a row is clicked, **When** it expands, **Then** the recorded arguments and result are shown
+3. **Given** the pane is open, **When** a new tool call is recorded, **Then** it appears within one refresh interval without manual action
+4. **Given** the log is empty or absent, **When** the pane opens, **Then** an empty state is shown rather than an error
+5. **Given** an entry carries a truncation marker, **When** the row expands, **Then** the pane shows the marker and byte count rather than presenting partial data as complete
+6. **Given** Super Productivity is in dark mode, **When** the pane renders, **Then** it remains legible
+
+---
+
+### User Story 3 - Bounded Disk Use (Priority: P3)
+
+Full request/response capture is unbounded by nature — `get_tasks` returns the
+user's entire task list. The log must stay bounded without the user managing it.
+
+**Why this priority**: Correctness of the feature over time, not first-run value.
+
+**Independent Test**: Record more than the cap, verify line count and ordering.
+
+**Acceptance Scenarios**:
+
+1. **Given** more entries than the cap are recorded, **When** the file is read, **Then** it holds exactly the cap, oldest dropped
+2. **Given** the log file is created, **When** its mode is checked, **Then** it is 0600
+3. **Given** entries are recorded one at a time, **When** the file is under the prune threshold, **Then** no full rewrite occurs
+
+---
+
+### Edge Cases
+
+- Two MCP clients each spawn a server, so two processes append to one file. Single-line appends in `O_APPEND` mode do not interleave at these sizes; pruning is read-modify-write and is last-writer-wins. What a race loses is log entries, never user data.
+- A partially written or corrupt line: the pane skips unparseable lines and renders the rest.
+- The log file does not exist yet (fresh install, first pane open): empty state, not an error.
+- A tool with no arguments records `args: {}`, not `null`.
+- A payload that is exactly at the cap is kept whole; the marker applies strictly above it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements — Recording
+
+- **FR-001**: System MUST append one JSON object per line to `<base>/tool-calls.jsonl` for every MCP tool invocation
+- **FR-002**: Each entry MUST contain `ts` (epoch ms), `tool` (the MCP tool name), `args`, `ms` (duration), `ok` (boolean), and either `result` or `error`
+- **FR-003**: Recording MUST wrap tool registration, not the IPC layer, so entries carry MCP tool names rather than plugin action names
+- **FR-004**: A recording failure MUST NOT alter or fail the tool call — the exception is caught and discarded, and the tool's own result is returned as if recording had succeeded
+- **FR-005**: The wrapper MUST return the handler's result unchanged
+- **FR-006**: A serialized `args` or `result` over 8192 bytes MUST be replaced by `{ _truncated: true, bytes: <n>, preview: <string> }`
+- **FR-007**: The log file MUST be created at mode 0600 within the existing 0700 base directory
+- **FR-008**: The log MUST retain at most 500 entries, dropping the oldest first
+- **FR-009**: Pruning MUST be amortized — a full rewrite only once the file exceeds the cap by ~20%, not on every call
+- **FR-010**: A tool handler that throws MUST be recorded with `ok: false` and its exception re-thrown unchanged
+
+### Functional Requirements — Pane
+
+- **FR-011**: The plugin MUST expose its iframe pane in Super Productivity's menu (`isSkipMenuEntry: false`)
+- **FR-012**: The pane MUST read the log and render entries newest-first
+- **FR-013**: Each row MUST show local time, tool name, duration, and success/error status
+- **FR-014**: Clicking a row MUST reveal the recorded arguments and result
+- **FR-015**: The pane MUST refresh on an interval matching the plugin's existing 2000 ms cadence
+- **FR-016**: Unparseable lines MUST be skipped without failing the render
+- **FR-017**: A missing or empty log MUST produce an empty state
+- **FR-018**: The pane MUST use no external dependencies and require no build step, since `plugin.zip` is assembled by `zip` alone
+- **FR-019**: The pane MUST honour `prefers-color-scheme` so it stays legible against SP's dark theme
+
+### Key Entities
+
+- **ToolCallEntry**: `{ ts, tool, args, ms, ok, result? , error? }` — one line of the log
+- **TruncationMarker**: `{ _truncated: true, bytes, preview }` — stands in for an oversized `args` or `result`
+- **RingCap**: the retention rule — maximum entries, oldest dropped, applied on write
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A tool call appears in the open pane within 3 seconds of completing
+- **SC-002**: The log file stays under ~10 MB at worst case (500 entries × two 8 KB payloads plus overhead), regardless of session length
+- **SC-003**: Recording adds under 5 ms to a tool call on the append path. The amortized prune (FR-009) is exempt and MUST occur on fewer than 1 call in 100
+- **SC-004**: All 34 currently registered tools are recorded without editing any of them
+- **SC-005**: The existing 222 tests continue to pass unchanged
+
+## Assumptions
+
+- **Iframe context is unverified.** `plugin/index.html` currently loads `plugin.js` itself, so whether SP injects `PluginAPI` into the iframe — or whether iframe and background script are separate contexts — cannot be determined from this repo alone. Implementation MUST verify this before building the UI. If the iframe cannot reach `executeNodeScript`, the fallback is for the background script to read the log and push it to the iframe via `postMessage`. Both paths satisfy every requirement above; only the plumbing differs.
+- Both sides already resolve the same base directory (`src/ipc/directories.ts` and the plugin's own probe), so the log needs no new path logic.
+- No protocol version bump: the log is written and read outside the command/response protocol.
+- Concurrent servers are tolerated, not coordinated — no lock file. Last-writer-wins on prune is acceptable for a log.
+- `src/server.ts` hardcodes `version: '1.6.0'`, stale since the 1.7.0 release. It is corrected to read from `package.json` as part of this work, since the same file is being modified.

--- a/specs/006-tool-call-timeline/spec.md
+++ b/specs/006-tool-call-timeline/spec.md
@@ -114,7 +114,8 @@ user's entire task list. The log must stay bounded without the user managing it.
 - **FR-015**: The pane MUST refresh on an interval matching the plugin's existing 2000 ms cadence
 - **FR-016**: Unparseable lines MUST be skipped without failing the render
 - **FR-017**: A missing or empty log MUST produce an empty state
-- **FR-018**: The pane MUST use no external dependencies and require no build step, since `plugin.zip` is assembled by `zip` alone
+- **FR-018**: The pane MUST use no external dependencies. Its JavaScript MUST be inlined into `index.html` at build time: SP serves only `index.html` to the iframe (via `srcdoc`) and does not serve arbitrary extra files from the ZIP, so a `<script src="dashboard.js">` tag fetches nothing and fails silently
+- **FR-018a**: The pane MUST NOT depend on `DOMContentLoaded` still being pending when its script runs — under `srcdoc` that is undocumented, and a missed event leaves the pane permanently blank. It MUST branch on `document.readyState`
 - **FR-019**: The pane MUST honour `prefers-color-scheme` so it stays legible against SP's dark theme
 
 ### Key Entities
@@ -137,6 +138,7 @@ user's entire task list. The log must stay bounded without the user managing it.
 
 - **Iframe context — resolved from SP's plugin development guide.** Iframe plugins receive a filtered `window.PluginAPI` injected into `index.html`, and `executeNodeScript` is proxied through the host bridge for iframe plugins whenever the desktop app has granted `nodeExecution` — which this plugin already requests. The pane can therefore read the log directly and needs no `postMessage` bridge. What remains host-only is callback-heavy registration (`registerHeaderButton`, `registerMenuEntry`, `registerSidePanelButton`, `registerShortcut`, `registerConfigHandler`); this feature registers none of them, so `plugin.js` keeps its current role. Implementation should still confirm the proxy responds on first run — one `executeNodeScript` call from the iframe before the UI is built on top of it — since this is documented behaviour rather than something observed in this repo.
 - The stub iframe has never been reachable: SP requires the `showIndexHtmlAsView` permission to display plugin UI, and the manifest does not declare it (FR-011a). Enabling the pane means adding the permission, not just flipping `isSkipMenuEntry`.
+- The original assumption that `plugin.zip` needs no build step was wrong, and cost a debugging cycle: the pane shipped with an external `<script src>` that SP never served, so it rendered its header and nothing else. `scripts/build-plugin.mjs` now inlines `plugin/dashboard.js` into `index.html` at build time. `dashboard.js` remains the source of truth and is what the unit tests import.
 - Both sides already resolve the same base directory (`src/ipc/directories.ts` and the plugin's own probe), so the log needs no new path logic.
 - No protocol version bump: the log is written and read outside the command/response protocol.
 - Concurrent servers are tolerated, not coordinated — no lock file. Last-writer-wins on prune is acceptable for a log.

--- a/specs/006-tool-call-timeline/spec.md
+++ b/specs/006-tool-call-timeline/spec.md
@@ -106,6 +106,8 @@ user's entire task list. The log must stay bounded without the user managing it.
 ### Functional Requirements — Pane
 
 - **FR-011**: The plugin MUST expose its iframe pane in Super Productivity's menu (`isSkipMenuEntry: false`)
+- **FR-011a**: `plugin/manifest.json` MUST declare the `showIndexHtmlAsView` permission, which SP requires to display plugin UI at all. The manifest currently declares only `nodeExecution`
+- **FR-011b**: The pane MUST read the log via the `executeNodeScript` proxied into the iframe, not via a `postMessage` bridge to `plugin.js`
 - **FR-012**: The pane MUST read the log and render entries newest-first
 - **FR-013**: Each row MUST show local time, tool name, duration, and success/error status
 - **FR-014**: Clicking a row MUST reveal the recorded arguments and result
@@ -133,7 +135,8 @@ user's entire task list. The log must stay bounded without the user managing it.
 
 ## Assumptions
 
-- **Iframe context is unverified.** `plugin/index.html` currently loads `plugin.js` itself, so whether SP injects `PluginAPI` into the iframe — or whether iframe and background script are separate contexts — cannot be determined from this repo alone. Implementation MUST verify this before building the UI. If the iframe cannot reach `executeNodeScript`, the fallback is for the background script to read the log and push it to the iframe via `postMessage`. Both paths satisfy every requirement above; only the plumbing differs.
+- **Iframe context — resolved from SP's plugin development guide.** Iframe plugins receive a filtered `window.PluginAPI` injected into `index.html`, and `executeNodeScript` is proxied through the host bridge for iframe plugins whenever the desktop app has granted `nodeExecution` — which this plugin already requests. The pane can therefore read the log directly and needs no `postMessage` bridge. What remains host-only is callback-heavy registration (`registerHeaderButton`, `registerMenuEntry`, `registerSidePanelButton`, `registerShortcut`, `registerConfigHandler`); this feature registers none of them, so `plugin.js` keeps its current role. Implementation should still confirm the proxy responds on first run — one `executeNodeScript` call from the iframe before the UI is built on top of it — since this is documented behaviour rather than something observed in this repo.
+- The stub iframe has never been reachable: SP requires the `showIndexHtmlAsView` permission to display plugin UI, and the manifest does not declare it (FR-011a). Enabling the pane means adding the permission, not just flipping `isSkipMenuEntry`.
 - Both sides already resolve the same base directory (`src/ipc/directories.ts` and the plugin's own probe), so the log needs no new path logic.
 - No protocol version bump: the log is written and read outside the command/response protocol.
 - Concurrent servers are tolerated, not coordinated — no lock file. Last-writer-wins on prune is acceptable for a log.

--- a/specs/007-worklog-write-path/spec.md
+++ b/specs/007-worklog-write-path/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Worklog Write Path
+
+**Feature Branch**: `007-worklog-write-path`
+**Created**: 2026-09-01
+**Status**: Draft
+**Input**: Make the per-day worklog the deliberate, only writable representation of time spent — multi-day `log_time`, documented reads, and removal of the bare `timeSpent` write that can produce a state SP's own model forbids.
+
+## Context
+
+In Super Productivity, `timeSpentOnDay` is authoritative and `timeSpent` is always
+derived from it. Three independent paths in SP's source agree:
+
+| Path | Writes |
+|------|--------|
+| Task reducer (`addTimeSpent`, `roundTimeSpentForDay`, `addSubTask`) | `timeSpentOnDay[date]`, then `timeSpent = calcTotalTimeSpent(...)` |
+| Time-estimate dialog (user edits "time spent") | `timeSpentOnDay: { ...copy, [getDbDateStr(date)]: value }` |
+| Short syntax `1h/2h` | `timeSpentOnDay: { ...task.timeSpentOnDay, [getDbDateStr()]: ms }` |
+
+SP has no path that sets `timeSpent` directly. Parents are recomputed via
+`reCalcTimeSpentForParentIfParent`.
+
+This repo has two paths that do set it directly — `update_task`
+(`src/tools/tasks.ts:317`) and `bulk_update_tasks` (`src/tools/tasks.ts:448`) —
+both writing through the generic `PluginAPI.updateTask`, which bypasses SP's
+recompute. They can produce a task where `timeSpent ≠ sum(timeSpentOnDay)`: a
+state SP cannot represent and will silently discard the next time anything
+touches that task's time.
+
+Reading the map already works, but by accident rather than design: the `fields`
+filter is `if (f in t)`, so `timeSpentOnDay` passes through while appearing in no
+documentation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Logging Several Days at Once (Priority: P1)
+
+`log_time` accepts a list of day/duration pairs, so backfilling or correcting a
+stretch of history is one call rather than N — and without ever handing the
+caller a whole map to edit and send back.
+
+**Why this priority**: The capability gap. Single-day logging already works;
+multi-day is what a whole-map write on `update_task` would have bought, minus
+the race.
+
+**Independent Test**: Log three days in one call, read the task back, verify all
+three days and the recomputed total.
+
+**Acceptance Scenarios**:
+
+1. **Given** `entries: [{date, duration}, ...]`, **When** called, **Then** each day is applied and the total is recomputed once from the final map
+2. **Given** both `duration` and `entries`, **When** called, **Then** an error is returned — they are mutually exclusive
+3. **Given** neither `duration` nor `entries`, **When** called, **Then** an error is returned
+4. **Given** `entries` containing the same date twice, **When** called, **Then** an error is returned rather than one entry silently winning
+5. **Given** `entries: []`, **When** called, **Then** an error is returned — a call that writes nothing is a mistake, not a no-op
+6. **Given** `mode`, **When** called with `entries`, **Then** it applies to every entry
+7. **Given** any entry with an invalid duration or date, **When** called, **Then** the whole call fails and nothing is written
+8. **Given** the task has a parent, **When** several days are logged, **Then** the parent receives the delta for each affected day in a single update
+
+---
+
+### User Story 2 - Reading the Worklog on Purpose (Priority: P2)
+
+The per-day map becomes a documented, deliberate part of the read surface
+instead of something that happens to work.
+
+**Why this priority**: It already functions; this makes it dependable.
+
+**Independent Test**: Request `fields: ["timeSpentOnDay"]` and read the resource
+summary; both return the map.
+
+**Acceptance Scenarios**:
+
+1. **Given** the README and spec 005's valid-field list, **When** read, **Then** `timeSpentOnDay` appears in both
+2. **Given** the MCP task resource summary, **When** fetched, **Then** it includes `timeSpentOnDay` alongside `timeSpent`
+3. **Given** an existing `fields: ["timeSpentOnDay"]` call, **When** made, **Then** its behaviour is unchanged
+
+---
+
+### User Story 3 - Removing the Write SP Cannot Represent (Priority: P3)
+
+`time_spent` is removed from `update_task` and `bulk_update_tasks`. The total
+stays fully readable; it is simply no longer settable, because SP derives it.
+
+**Why this priority**: Stops new divergent tasks. Breaking, so it is sequenced
+after the replacement capability exists.
+
+**Independent Test**: Call `update_task` with `time_spent` and confirm a
+validation error naming `log_time`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `update_task` with `time_spent`, **When** called, **Then** validation fails (schemas are `.strict()`) and the tool description directs the caller to `log_time`
+2. **Given** a `bulk_update_tasks` item with `time_spent`, **When** called, **Then** validation fails
+3. **Given** `time_estimate`, **When** set through either tool, **Then** it still works — SP stores `timeEstimate` directly, so it is a genuine standalone field
+4. **Given** any other `update_task` field, **When** set, **Then** behaviour is unchanged
+
+---
+
+### Edge Cases
+
+- A task whose `timeSpent` already diverges from its map (such as one imported from another source): `log_time` recomputes from the map, matching SP. The unattributed total is not preserved — SP would overwrite it at the next timer tick regardless — but the response reports what it was, so the change is visible rather than silent (FR-012).
+- SP's timer is running on a day being logged: `log_time` sends durations, not a map, and the read-modify-write happens inside the plugin within one command. The exposure is one command, the same as SP's own writes — not the length of an agent's turn, which a whole-map write would have been.
+- Logging `0m` in `set` mode for a day removes that day's entry, as today.
+- A date in the future or far past is accepted; SP's own dialog permits arbitrary dates and the worklog is a record, not a schedule.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements — Multi-day logging
+
+- **FR-001**: `log_time` MUST accept `entries: [{ date, duration }, ...]` as an alternative to `duration`/`date`
+- **FR-002**: `duration` and `entries` MUST be mutually exclusive; supplying both, or neither, is an error
+- **FR-003**: `entries` MUST reject duplicate dates
+- **FR-003a**: Each entry's `date` MUST be ISO `YYYY-MM-DD` and its `duration` MUST be SP short syntax, validated identically to the single-day form — the multi-day path introduces no second set of parsing rules
+- **FR-003b**: `entries` MUST be capped at 100, matching the existing bulk tools (`bulk_update_tasks`, `bulk_complete_tasks`)
+- **FR-004**: `entries` MUST reject an empty array
+- **FR-005**: Every entry MUST be validated before any write; one invalid entry fails the call with nothing written
+- **FR-006**: `mode` MUST apply to every entry in the call
+- **FR-007**: `timeSpent` MUST be recomputed once from the final map, not once per entry
+- **FR-008**: A parent task MUST receive the delta for every affected day in a single update
+- **FR-009**: The response MUST return the resulting map and total
+
+### Functional Requirements — Reads
+
+- **FR-010**: `timeSpentOnDay` MUST be documented as a valid `fields` value in the README and in spec 005's valid-field list
+- **FR-011**: The MCP task resource summary MUST include `timeSpentOnDay`
+- **FR-012**: When the task's `timeSpent` differed from the sum of its map before the write, the response MUST report the previous total, so a corrected divergence is visible to the caller
+
+### Functional Requirements — Removal
+
+- **FR-013**: `time_spent` MUST be removed from the `update_task` schema
+- **FR-014**: `time_spent` MUST be removed from the `bulk_update_tasks` item schema
+- **FR-015**: Both tool descriptions MUST direct callers to `log_time` for writing time
+- **FR-016**: `time_estimate` MUST remain writable through both tools
+
+### Key Entities
+
+- **WorklogEntry**: `{ date, duration }` — one day's contribution in a multi-day call. `date` is ISO `YYYY-MM-DD`; `duration` is SP short syntax (`2h`, `45m`, `1h30m`). Unlike the single-day form, `date` is required — a list of entries has no sensible "default to today"
+- **Per-day map** (`timeSpentOnDay`): the authoritative record; the total is derived from it
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Backfilling seven days takes one `log_time` call
+- **SC-002**: No tool in this server can produce a task where `timeSpent ≠ sum(timeSpentOnDay)`
+- **SC-003**: Existing single-day `log_time` calls behave identically — the multi-day form is additive
+- **SC-004**: The caller never holds a `timeSpentOnDay` map between a read and a write, so no agent-length window exists in which SP's timer can be clobbered
+
+## Assumptions
+
+- This is a breaking change to `update_task` and `bulk_update_tasks`, warranting a minor version bump. Because the schemas are `.strict()`, a caller passing `time_spent` gets an immediate validation error rather than a silent behaviour change — a loud failure with a message pointing at `log_time`.
+- Divergent totals are not preserved. SP discards them at the next write to the task's time, so preserving one would manufacture a state SP's model forbids and then lose it anyway. FR-012 makes the correction visible instead.
+- `applyDayTime` in `plugin/plugin.js` generalizes from one day to many: apply each day, recompute the total once, and roll the per-day deltas to the parent in a single update. It stays a private plugin helper, not an MCP action.
+- No protocol version bump — `logTime` gains fields in its `data` payload, which is additive.

--- a/specs/007-worklog-write-path/spec.md
+++ b/specs/007-worklog-write-path/spec.md
@@ -148,7 +148,7 @@ validation error naming `log_time`.
 
 ## Assumptions
 
-- This is a breaking change to `update_task` and `bulk_update_tasks`, warranting a minor version bump. Because the schemas are `.strict()`, a caller passing `time_spent` gets an immediate validation error rather than a silent behaviour change — a loud failure with a message pointing at `log_time`.
+- This is a breaking change to `update_task` and `bulk_update_tasks`, but ships without a version bump. Because the schemas are `.strict()`, a caller passing `time_spent` gets an immediate validation error rather than a silent behaviour change — a loud failure with a message pointing at `log_time` — so the break announces itself without needing a version to signal it.
 - Divergent totals are not preserved. SP discards them at the next write to the task's time, so preserving one would manufacture a state SP's model forbids and then lose it anyway. FR-012 makes the correction visible instead.
 - `applyDayTime` in `plugin/plugin.js` generalizes from one day to many: apply each day, recompute the total once, and roll the per-day deltas to the parent in a single update. It stays a private plugin helper, not an MCP action.
 - No protocol version bump — `logTime` gains fields in its `data` payload, which is additive.

--- a/src/recording/instrument.ts
+++ b/src/recording/instrument.ts
@@ -1,0 +1,91 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Recorder } from './recorder.js';
+
+/**
+ * Recording wraps tool registration rather than the IPC layer. The IPC layer
+ * only sees plugin actions — `get_worklog` and `log_time` both send `getTasks`,
+ * and several tools send more than one command — so an IPC-level record could
+ * not name the tool the client actually called.
+ */
+
+interface ToolResultShape {
+  content?: { type?: string; text?: string }[];
+  isError?: boolean;
+}
+
+export interface Outcome {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Unwrap an MCP tool result into what belongs in the log. Tool results carry
+ * their payload as JSON inside a text content block; storing that envelope raw
+ * would make the pane show escaped JSON instead of the data.
+ */
+export function extractOutcome(value: unknown): Outcome {
+  const shaped = value as ToolResultShape;
+  const text = shaped?.content?.[0]?.text;
+  if (typeof text !== 'string') return { ok: true, result: value };
+
+  let payload: unknown = text;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    // Not JSON — keep the raw text rather than losing it.
+  }
+
+  if (shaped.isError) {
+    const message = (payload as { error?: unknown })?.error;
+    return { ok: false, error: typeof message === 'string' ? message : text };
+  }
+  return { ok: true, result: payload };
+}
+
+type ToolHandler = (...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Return a server that records every tool call. Non-tool members (resources,
+ * connect, …) pass straight through, so this is transparent to the seven
+ * `register*Tools` functions and needs no per-tool changes.
+ */
+export function instrumentServer(server: McpServer, recorder: Recorder): McpServer {
+  return new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop !== 'registerTool') {
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+
+      return (name: string, config: unknown, handler: ToolHandler) => {
+        const wrapped = async (...callArgs: unknown[]): Promise<unknown> => {
+          const started = Date.now();
+          const args = callArgs[0] ?? {};
+
+          const write = (outcome: Outcome) => {
+            try {
+              recorder.record({ ts: started, tool: name, args, ms: Date.now() - started, ...outcome });
+            } catch {
+              // A recorder is contracted not to throw, but the tool call must
+              // survive one that does regardless (FR-004).
+            }
+          };
+
+          try {
+            const result = await handler(...callArgs);
+            write(extractOutcome(result));
+            return result;
+          } catch (err) {
+            write({ ok: false, error: err instanceof Error ? err.message : String(err) });
+            throw err;
+          }
+        };
+
+        return (target.registerTool as unknown as (n: string, c: unknown, h: ToolHandler) => unknown)(
+          name, config, wrapped,
+        );
+      };
+    },
+  });
+}

--- a/src/recording/recorder.ts
+++ b/src/recording/recorder.ts
@@ -1,0 +1,92 @@
+import { appendFileSync, existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ResolvedDirs } from '../ipc/directories.js';
+import { needsPrune, prune } from './ring.js';
+import { truncatePayload } from './truncate.js';
+
+export const LOG_FILENAME = 'tool-calls.jsonl';
+
+/** Retention cap — the log holds at most this many entries (FR-008). */
+const DEFAULT_MAX_ENTRIES = 500;
+/** Per-payload size cap before the truncation marker takes over (FR-006). */
+const DEFAULT_MAX_PAYLOAD_BYTES = 8192;
+
+export interface ToolCallEntry {
+  ts: number;
+  tool: string;
+  args: unknown;
+  ms: number;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+export interface Recorder {
+  record(entry: ToolCallEntry): void;
+}
+
+export interface RecorderOptions {
+  max?: number;
+  maxPayloadBytes?: number;
+}
+
+function countExistingEntries(path: string): number {
+  if (!existsSync(path)) return 0;
+  try {
+    return readFileSync(path, 'utf-8').split('\n').filter(line => line.trim() !== '').length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Records tool calls to a JSONL log in the shared IPC directory, where the SP
+ * plugin's pane can read it.
+ *
+ * Recording is best-effort by design: a logging failure must never surface to
+ * the caller, because the user asked to update a task, not to write a log
+ * (FR-004). Every path here swallows its errors deliberately.
+ */
+export function createRecorder(dirs: ResolvedDirs, opts: RecorderOptions = {}): Recorder {
+  const max = opts.max ?? DEFAULT_MAX_ENTRIES;
+  const maxPayloadBytes = opts.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  const path = join(dirs.base, LOG_FILENAME);
+
+  // Seeded from disk so a cap survives across sessions — a stdio server is
+  // spawned afresh for every client session, so an in-memory-only count would
+  // let the log grow without bound.
+  let entryCount = countExistingEntries(path);
+
+  function rewritePruned(): void {
+    const kept = prune(readFileSync(path, 'utf-8').split('\n'), max);
+    // Write-and-rename so a crash mid-prune can't leave a half-written log.
+    // Concurrent servers are last-writer-wins; what a race loses is log lines.
+    const tmp = `${path}.${process.pid}.tmp`;
+    try {
+      writeFileSync(tmp, kept.length ? `${kept.join('\n')}\n` : '', { mode: 0o600 });
+      renameSync(tmp, path);
+      entryCount = kept.length;
+    } catch (err) {
+      try { unlinkSync(tmp); } catch { /* nothing to clean up */ }
+      throw err;
+    }
+  }
+
+  return {
+    record(entry: ToolCallEntry): void {
+      try {
+        const line = JSON.stringify({
+          ...entry,
+          args: truncatePayload(entry.args, maxPayloadBytes),
+          result: truncatePayload(entry.result, maxPayloadBytes),
+        });
+        appendFileSync(path, `${line}\n`, { mode: 0o600 });
+        entryCount++;
+
+        if (needsPrune(entryCount, max)) rewritePruned();
+      } catch {
+        // Deliberate: the tool call's result matters, this log doesn't.
+      }
+    },
+  };
+}

--- a/src/recording/ring.ts
+++ b/src/recording/ring.ts
@@ -1,0 +1,21 @@
+// Retention for the tool-call log. The log is append-only on the hot path; the
+// cap is enforced by an occasional rewrite rather than on every call, so a chatty
+// session doesn't pay to rewrite the whole file each time a tool runs.
+
+/** Slack above the cap before a rewrite is worth doing. */
+const PRUNE_SLACK = 1.2;
+
+/**
+ * Whether the file has drifted far enough over the cap to be worth rewriting.
+ * The slack spans at least 100 appends, keeping the rewrite off the append path
+ * for 99 calls out of 100 (SC-003).
+ */
+export function needsPrune(lineCount: number, max: number): boolean {
+  return lineCount > Math.floor(max * PRUNE_SLACK);
+}
+
+/** Keep the newest `max` entries, dropping the oldest. Blank lines are discarded. */
+export function prune(lines: string[], max: number): string[] {
+  const entries = lines.filter(line => line.trim() !== '');
+  return entries.length <= max ? entries : entries.slice(-max);
+}

--- a/src/recording/truncate.ts
+++ b/src/recording/truncate.ts
@@ -1,0 +1,32 @@
+// Full request/response capture is unbounded by nature — get_tasks returns the
+// user's entire task list. Oversized payloads are replaced by a marker that says
+// how much was elided, so the pane can be honest about it rather than showing a
+// clipped object as if it were whole.
+
+export interface TruncationMarker {
+  _truncated: true;
+  bytes: number;
+  preview: string;
+}
+
+const PREVIEW_CHARS = 200;
+
+/** Return the payload as-is, or a marker if serializing it exceeds `maxBytes`. */
+export function truncatePayload(value: unknown, maxBytes: number): unknown {
+  if (value === undefined) return undefined;
+
+  let json: string;
+  try {
+    json = JSON.stringify(value) ?? 'null';
+  } catch {
+    // Circular or otherwise unserializable — recording must not throw (FR-004).
+    return { _truncated: true, bytes: 0, preview: '<unserializable>' } satisfies TruncationMarker;
+  }
+
+  // Bytes, not characters: a string of multi-byte codepoints is far larger on
+  // disk than its length suggests.
+  const bytes = Buffer.byteLength(json, 'utf8');
+  if (bytes <= maxBytes) return value;
+
+  return { _truncated: true, bytes, preview: json.slice(0, PREVIEW_CHARS) } satisfies TruncationMarker;
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -14,6 +14,7 @@ interface TaskRecord {
   plannedAt?: number | null;
   timeEstimate: number;
   timeSpent: number;
+  timeSpentOnDay?: Record<string, number>;
   [key: string]: unknown;
 }
 
@@ -27,6 +28,7 @@ function shapeTask(t: TaskRecord) {
     plannedAt: t.plannedAt ?? null,
     timeEstimate: t.timeEstimate,
     timeSpent: t.timeSpent,
+    timeSpentOnDay: t.timeSpentOnDay ?? {},
     parentId: t.parentId ?? null,
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,24 @@ import { registerHabitTools } from './tools/habits.js';
 import { registerNotificationTools } from './tools/notifications.js';
 import { registerDiagnosticTools } from './tools/diagnostics.js';
 import { registerResources } from './resources/index.js';
+import { createRecorder } from './recording/recorder.js';
+import { instrumentServer } from './recording/instrument.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Read the version from package.json rather than repeating it here — the
+ * hardcoded copy went stale at the 1.7.0 release without anything noticing.
+ * The relative path resolves the same from src/ and from the bundled dist/.
+ */
+export function readPackageVersion(): string {
+  try {
+    const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
+    return JSON.parse(readFileSync(pkgPath, 'utf-8')).version as string;
+  } catch {
+    return '0.0.0';
+  }
+}
 
 export function createServer(): { server: McpServer; dirs: ResolvedDirs } {
   const dirs = resolveDirectories();
@@ -16,16 +34,20 @@ export function createServer(): { server: McpServer; dirs: ResolvedDirs } {
 
   const server = new McpServer({
     name: 'super-productivity',
-    version: '1.6.0',
+    version: readPackageVersion(),
   });
 
-  registerTaskTools(server, dirs);
-  registerProjectTools(server, dirs);
-  registerTagTools(server, dirs);
-  registerHabitTools(server, dirs);
-  registerNotificationTools(server, dirs);
-  registerDiagnosticTools(server, dirs);
-  registerResources(server, dirs);
+  // Every tool registers through the instrumented wrapper, so all of them are
+  // recorded without a per-tool change. Non-tool members pass straight through.
+  const recording = instrumentServer(server, createRecorder(dirs));
+
+  registerTaskTools(recording, dirs);
+  registerProjectTools(recording, dirs);
+  registerTagTools(recording, dirs);
+  registerHabitTools(recording, dirs);
+  registerNotificationTools(recording, dirs);
+  registerDiagnosticTools(recording, dirs);
+  registerResources(recording, dirs);
 
   return { server, dirs };
 }

--- a/src/tools/duration.ts
+++ b/src/tools/duration.ts
@@ -1,0 +1,25 @@
+// Duration short syntax ("1h30m", "45m", "90s") — the same shape SP accepts in a
+// task title. Kept pure and separately tested, like habit-streak.ts: the log_time
+// tool turns a parse failure into an errorResult rather than a silent zero, so a
+// typo can never be mistaken for "logged nothing".
+
+const UNIT_MS: Record<string, number> = { h: 3_600_000, m: 60_000, s: 1_000 };
+
+// Only whole `<digits><h|m|s>` tokens, and the pattern must consume the entire
+// string — that rejects "90" (no unit), "1h30" (trailing unitless number),
+// "1.5h", "-1h" and "1d" instead of silently parsing the part it recognizes.
+const DURATION_RE = /^(?:\d+\s*[hms]\s*)+$/i;
+const TOKEN_RE = /(\d+)\s*([hms])/gi;
+
+/** Parse a duration string to milliseconds. Returns null if the string isn't a valid duration. */
+export function parseDuration(input: string): number | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!DURATION_RE.test(trimmed)) return null;
+
+  let ms = 0;
+  for (const [, amount, unit] of trimmed.matchAll(TOKEN_RE)) {
+    ms += parseInt(amount, 10) * UNIT_MS[unit.toLowerCase()];
+  }
+  return ms;
+}

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -4,6 +4,7 @@ import type { ResolvedDirs } from '../ipc/directories.js';
 import { sendCommand } from '../ipc/command-sender.js';
 import type { TaskFilters } from '../ipc/types.js';
 import { errorResult, okResult } from './result.js';
+import { parseDuration } from './duration.js';
 
 interface TaskRecord {
   id: string;
@@ -191,6 +192,14 @@ const getWorklogShape = {
   end_date: z.string().describe('End date (ISO format, e.g. 2026-04-20)'),
 };
 export const getWorklogSchema = z.object(getWorklogShape).strict();
+
+const logTimeShape = {
+  task_id: z.string().describe('Task ID to log time against'),
+  duration: z.string().describe('Duration in SP short syntax: 2h, 45m, 1h30m, 90s'),
+  date: z.string().optional().describe('Day to log against (ISO format, e.g. 2026-08-31). Defaults to today.'),
+  mode: z.enum(['add', 'set']).optional().default('add').describe('"add" increments that day\'s tracked time; "set" overwrites it — pass 0m with "set" to clear the day'),
+};
+export const logTimeSchema = z.object(logTimeShape).strict();
 
 const getTaskRepeatCfgsShape = {};
 export const getTaskRepeatCfgsSchema = z.object(getTaskRepeatCfgsShape).strict();
@@ -593,6 +602,35 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
           ? { estimateMs: totalEstimate, actualMs: totalActual, ratio: totalActual / totalEstimate }
           : null,
       });
+    },
+  );
+
+  // log_time — writes the per-day map get_worklog reads
+  server.registerTool(
+    'log_time',
+    {
+      description: 'Log time spent on a task for a specific day. Adds to that day\'s tracked time by default, or overwrites it with mode "set" (pass 0m with "set" to clear a day). Time lands in the same per-day record SP\'s own timer writes, so it shows up in the worklog and rolls up to the parent task.',
+      inputSchema: logTimeSchema,
+    },
+    async ({ task_id, duration, date, mode }) => {
+      if (!task_id?.trim()) return errorResult('task_id is required');
+
+      const durationMs = parseDuration(duration ?? '');
+      if (durationMs === null) {
+        return errorResult(`Invalid duration "${duration}" — use SP short syntax, e.g. 2h, 45m, 1h30m or 90s`);
+      }
+
+      const day = date ?? localDateStr();
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+        return errorResult(`Invalid date "${day}" — expected ISO format YYYY-MM-DD`);
+      }
+
+      const res = await sendCommand(dirs, 'logTime', {
+        taskId: task_id,
+        data: { date: day, durationMs, mode: mode ?? 'add' },
+      });
+      if (!res.success) return errorResult(res.error ?? 'Failed to log time');
+      return okResult(res.result);
     },
   );
 

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -96,7 +96,6 @@ const updateTaskShape = {
   deadline_day: z.string().optional().describe('Deadline date in ISO format (e.g. 2026-04-20), or empty string to clear. Independent from due_day/planned_at.'),
   planned_at: z.number().nullable().optional().describe('Unix ms timestamp to plan task for a specific time (e.g. start of today = plan for today). Pass null to unplan. Independent from due_day.'),
   time_estimate: z.number().optional().describe('Time estimate in milliseconds'),
-  time_spent: z.number().optional().describe('Time spent in milliseconds'),
   tag_ids: z.array(z.string()).optional().describe('Bulk-replace all tags with this list (FR-003)'),
 };
 export const updateTaskSchema = z.object(updateTaskShape).strict();
@@ -142,7 +141,6 @@ const bulkUpdateTaskItemShape = {
   deadline_day: z.string().optional().describe('Deadline date (YYYY-MM-DD) or empty string to clear'),
   tag_ids: z.array(z.string()).optional().describe('Replace all tags'),
   time_estimate: z.number().optional().describe('Time estimate in ms'),
-  time_spent: z.number().optional().describe('Time spent in ms'),
 };
 export const bulkUpdateTaskItemSchema = z.object(bulkUpdateTaskItemShape).strict();
 const bulkUpdateTasksShape = {
@@ -193,11 +191,18 @@ const getWorklogShape = {
 };
 export const getWorklogSchema = z.object(getWorklogShape).strict();
 
+const worklogEntryShape = {
+  date: z.string().describe('Day to log against (ISO format, e.g. 2026-08-31)'),
+  duration: z.string().describe('Duration in SP short syntax: 2h, 45m, 1h30m, 90s'),
+};
+export const worklogEntrySchema = z.object(worklogEntryShape).strict();
+
 const logTimeShape = {
   task_id: z.string().describe('Task ID to log time against'),
-  duration: z.string().describe('Duration in SP short syntax: 2h, 45m, 1h30m, 90s'),
-  date: z.string().optional().describe('Day to log against (ISO format, e.g. 2026-08-31). Defaults to today.'),
-  mode: z.enum(['add', 'set']).optional().default('add').describe('"add" increments that day\'s tracked time; "set" overwrites it — pass 0m with "set" to clear the day'),
+  duration: z.string().optional().describe('Duration in SP short syntax: 2h, 45m, 1h30m, 90s. Single-day form — mutually exclusive with entries.'),
+  date: z.string().optional().describe('Day to log against (ISO format, e.g. 2026-08-31). Defaults to today. Only meaningful alongside duration.'),
+  entries: z.array(worklogEntrySchema).max(100).optional().describe('Log several days in one call, e.g. backfilling a week. Each entry needs its own date. Mutually exclusive with duration.'),
+  mode: z.enum(['add', 'set']).optional().default('add').describe('"add" increments each day\'s tracked time; "set" overwrites it — pass 0m with "set" to clear a day. Applies to every entry.'),
 };
 export const logTimeSchema = z.object(logTimeShape).strict();
 
@@ -297,10 +302,10 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
   server.registerTool(
     'update_task',
     {
-      description: 'Update an existing task. Supports SP short syntax in the title.',
+      description: 'Update an existing task. Supports SP short syntax in the title. Time spent is not settable here — SP derives it from the per-day worklog, so use log_time.',
       inputSchema: updateTaskSchema,
     },
-    async ({ task_id, title, notes, is_done, due_day, deadline_day, planned_at, time_estimate, time_spent, tag_ids }) => {
+    async ({ task_id, title, notes, is_done, due_day, deadline_day, planned_at, time_estimate, tag_ids }) => {
       if (!task_id?.trim()) return errorResult('task_id is required');
 
       const data: Record<string, unknown> = {};
@@ -314,7 +319,6 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       if (deadline_day !== undefined) data.deadlineDay = deadline_day || null;
       if (planned_at !== undefined) data.plannedAt = planned_at;
       if (time_estimate !== undefined) data.timeEstimate = time_estimate;
-      if (time_spent !== undefined) data.timeSpent = time_spent;
       // tag_ids replaces the entire tag list; use add_tag_to_task / remove_tag_from_task for incremental changes
       if (tag_ids !== undefined) data.tagIds = tag_ids;
 
@@ -432,7 +436,7 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
   server.registerTool(
     'bulk_update_tasks',
     {
-      description: 'Update multiple tasks in a single operation. Each item specifies a task_id and the fields to update. Uses partial-success semantics.',
+      description: 'Update multiple tasks in a single operation. Each item specifies a task_id and the fields to update. Uses partial-success semantics. Time spent is not settable here — SP derives it from the per-day worklog, so use log_time.',
       inputSchema: bulkUpdateTasksSchema,
     },
     async ({ updates }) => {
@@ -445,7 +449,6 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
           ...(u.deadline_day !== undefined && { deadlineDay: u.deadline_day || null }),
           ...(u.tag_ids !== undefined && { tagIds: u.tag_ids }),
           ...(u.time_estimate !== undefined && { timeEstimate: u.time_estimate }),
-          ...(u.time_spent !== undefined && { timeSpent: u.time_spent }),
         },
       }));
       const res = await sendCommand(dirs, 'bulkUpdateTasks', { updates: mapped });
@@ -612,22 +615,44 @@ export function registerTaskTools(server: McpServer, dirs: ResolvedDirs): void {
       description: 'Log time spent on a task for a specific day. Adds to that day\'s tracked time by default, or overwrites it with mode "set" (pass 0m with "set" to clear a day). Time lands in the same per-day record SP\'s own timer writes, so it shows up in the worklog and rolls up to the parent task.',
       inputSchema: logTimeSchema,
     },
-    async ({ task_id, duration, date, mode }) => {
+    async ({ task_id, duration, date, entries, mode }) => {
       if (!task_id?.trim()) return errorResult('task_id is required');
 
-      const durationMs = parseDuration(duration ?? '');
-      if (durationMs === null) {
-        return errorResult(`Invalid duration "${duration}" — use SP short syntax, e.g. 2h, 45m, 1h30m or 90s`);
+      if (entries !== undefined && duration !== undefined) {
+        return errorResult('Pass either duration (one day) or entries (several days), not both');
+      }
+      if (entries === undefined && duration === undefined) {
+        return errorResult('Pass duration to log one day, or entries to log several');
       }
 
-      const day = date ?? localDateStr();
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
-        return errorResult(`Invalid date "${day}" — expected ISO format YYYY-MM-DD`);
+      // The single-day form is just a one-entry list — one validation path and one
+      // wire shape, so the two forms cannot drift apart.
+      const requested = entries ?? [{ date: date ?? localDateStr(), duration: duration as string }];
+      if (requested.length === 0) return errorResult('entries must contain at least one day');
+
+      // Validate everything before sending: a partially-applied multi-day write
+      // would leave the worklog in a state the caller never asked for.
+      const seen = new Set<string>();
+      const normalised: { date: string; durationMs: number }[] = [];
+      for (const entry of requested) {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(entry.date)) {
+          return errorResult(`Invalid date "${entry.date}" — expected ISO format YYYY-MM-DD`);
+        }
+        if (seen.has(entry.date)) {
+          return errorResult(`Duplicate date "${entry.date}" in entries — one entry per day`);
+        }
+        seen.add(entry.date);
+
+        const durationMs = parseDuration(entry.duration ?? '');
+        if (durationMs === null) {
+          return errorResult(`Invalid duration "${entry.duration}" for ${entry.date} — use SP short syntax, e.g. 2h, 45m, 1h30m or 90s`);
+        }
+        normalised.push({ date: entry.date, durationMs });
       }
 
-      const res = await sendCommand(dirs, 'logTime', {
+      const res = await sendCommand(dirs, 'logTimeEntries', {
         taskId: task_id,
-        data: { date: day, durationMs, mode: mode ?? 'add' },
+        data: { entries: normalised, mode: mode ?? 'add' },
       });
       if (!res.success) return errorResult(res.error ?? 'Failed to log time');
       return okResult(res.result);

--- a/tests/unit/build/inline-pane.test.ts
+++ b/tests/unit/build/inline-pane.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { inlinePaneScript } from '../../../scripts/build-plugin.mjs';
+
+// SP does not serve arbitrary files from the plugin ZIP to the iframe — only
+// index.html itself is loaded (via srcdoc). A <script src="dashboard.js"> tag
+// silently fetches nothing, which is why the pane rendered its header and then
+// stopped. The pane's JS has to be inlined at build time.
+describe('inlinePaneScript', () => {
+  const html = '<body>\n  <main id="entries"></main>\n  <script src="dashboard.js"></script>\n</body>';
+
+  it('replaces the external script tag with the script body', () => {
+    const out = inlinePaneScript(html, 'function parseLog() { return []; }');
+    expect(out).toContain('function parseLog()');
+  });
+
+  it('leaves no external src reference behind', () => {
+    const out = inlinePaneScript(html, 'var x = 1;');
+    expect(out).not.toContain('src="dashboard.js"');
+  });
+
+  it('keeps the rest of the document intact', () => {
+    const out = inlinePaneScript(html, 'var x = 1;');
+    expect(out).toContain('<main id="entries"></main>');
+  });
+
+  it('strips the CommonJS export block, which has no meaning in a browser', () => {
+    const js = "var a = 1;\nif (typeof module !== 'undefined' && module.exports) {\n  module.exports = { a: a };\n}\nvar b = 2;";
+    const out = inlinePaneScript(html, js);
+    expect(out).not.toContain('module.exports');
+    expect(out).toContain('var a = 1;');
+    expect(out).toContain('var b = 2;');
+  });
+
+  it('does not let a closing tag in the JS break out of the script element', () => {
+    const out = inlinePaneScript(html, 'var s = "</script>";');
+    expect(out).not.toContain('"</script>"');
+    expect(out).toContain('<\\/script>');
+  });
+
+  it('throws when the expected tag is missing, rather than shipping a dead pane', () => {
+    expect(() => inlinePaneScript('<body></body>', 'var x = 1;')).toThrow(/dashboard\.js/);
+  });
+});

--- a/tests/unit/plugin/dashboard.test.ts
+++ b/tests/unit/plugin/dashboard.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { parseLog, formatDuration, formatTime, entryKey, hasChanged } from '../../../plugin/dashboard.js';
+
+describe('parseLog', () => {
+  const line = (over = {}) =>
+    JSON.stringify({ ts: 1_756_742_531_000, tool: 'get_tasks', args: {}, ms: 82, ok: true, result: [], ...over });
+
+  it('parses one entry per line', () => {
+    const entries = parseLog([line(), line({ tool: 'log_time' })].join('\n'));
+    expect(entries).toHaveLength(2);
+  });
+
+  it('returns newest first (FR-012)', () => {
+    const text = [line({ tool: 'oldest' }), line({ tool: 'newest' })].join('\n');
+    expect(parseLog(text).map(e => e.tool)).toEqual(['newest', 'oldest']);
+  });
+
+  it('skips a corrupt line without losing the rest (FR-016)', () => {
+    const text = [line({ tool: 'before' }), '{"half written', line({ tool: 'after' })].join('\n');
+    expect(parseLog(text).map(e => e.tool)).toEqual(['after', 'before']);
+  });
+
+  it('skips lines that parse but are not entries', () => {
+    const text = [line({ tool: 'real' }), 'null', '42', '"a string"'].join('\n');
+    expect(parseLog(text).map(e => e.tool)).toEqual(['real']);
+  });
+
+  it('tolerates a trailing newline', () => {
+    expect(parseLog(`${line()}\n`)).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty or absent log (FR-017)', () => {
+    expect(parseLog('')).toEqual([]);
+    expect(parseLog('   \n  ')).toEqual([]);
+    expect(parseLog(null)).toEqual([]);
+  });
+});
+
+describe('formatDuration', () => {
+  it('shows sub-second calls in milliseconds', () => {
+    expect(formatDuration(82)).toBe('82ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('switches to seconds at a second', () => {
+    expect(formatDuration(1000)).toBe('1.0s');
+    expect(formatDuration(1904)).toBe('1.9s');
+  });
+
+  it('switches to minutes past a minute', () => {
+    expect(formatDuration(65_000)).toBe('1m 5s');
+  });
+
+  it('handles zero', () => {
+    expect(formatDuration(0)).toBe('0ms');
+  });
+
+  it('does not render a missing duration as NaN', () => {
+    expect(formatDuration(undefined)).toBe('—');
+  });
+});
+
+describe('formatTime', () => {
+  it('renders a local wall-clock time', () => {
+    expect(formatTime(1_756_742_531_000)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('does not render a missing timestamp as Invalid Date', () => {
+    expect(formatTime(undefined)).toBe('—');
+  });
+});
+
+// The pane polls every 2s. Re-rendering unconditionally wiped any row the user
+// had expanded, so a click snapped shut within two seconds.
+describe('entryKey', () => {
+  it('is stable for the same entry across refreshes', () => {
+    const e = { ts: 1_756_742_531_000, tool: 'get_tasks', ms: 82, ok: true };
+    expect(entryKey(e)).toBe(entryKey({ ...e }));
+  });
+
+  it('distinguishes two calls to the same tool at different times', () => {
+    expect(entryKey({ ts: 1, tool: 'get_tasks' })).not.toBe(entryKey({ ts: 2, tool: 'get_tasks' }));
+  });
+
+  it('distinguishes two tools called at the same instant', () => {
+    expect(entryKey({ ts: 1, tool: 'get_tasks' })).not.toBe(entryKey({ ts: 1, tool: 'log_time' }));
+  });
+});
+
+describe('hasChanged', () => {
+  it('is false when the log is byte-identical, so open rows survive a refresh', () => {
+    expect(hasChanged('a\nb\n', 'a\nb\n')).toBe(false);
+  });
+
+  it('is true when a new entry is appended', () => {
+    expect(hasChanged('a\n', 'a\nb\n')).toBe(true);
+  });
+
+  it('is true on the very first read', () => {
+    expect(hasChanged(null, 'a\n')).toBe(true);
+  });
+});

--- a/tests/unit/plugin/executeCommand.test.ts
+++ b/tests/unit/plugin/executeCommand.test.ts
@@ -78,3 +78,127 @@ describe('executeCommand: bulkUpdateTasks partial-success with invalid task_id',
     expect(res.result.results).toEqual([{ id: 't1', success: false, error: 'boom' }]);
   });
 });
+
+// logTime writes the per-day map itself: PluginAPI has no addTimeSpent, only the
+// generic updateTask, so the plugin owns recomputing timeSpent and rolling the
+// delta up to the parent — the two things SP's own addTimeSpent action does.
+describe('executeCommand: logTime', () => {
+  const HOUR = 3_600_000;
+  let tasks: Record<string, unknown>[];
+
+  beforeEach(() => {
+    tasks = [];
+    globalThis.PluginAPI = {
+      addTask: vi.fn(),
+      updateTask: vi.fn().mockResolvedValue(undefined),
+      getTasks: vi.fn(async () => tasks),
+    };
+  });
+
+  const logTime = (taskId: string, data: Record<string, unknown>) =>
+    executeCommand({ action: 'logTime', taskId, data });
+
+  const patchFor = (taskId: string) =>
+    globalThis.PluginAPI.updateTask.mock.calls.find(([id]) => id === taskId)?.[1];
+
+  it("adds to an existing day's tracked time", async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-31': HOUR } }];
+    const res = await logTime('t1', { date: '2026-08-31', durationMs: HOUR / 2, mode: 'add' });
+    expect(res.success).toBe(true);
+    expect(patchFor('t1')).toEqual({
+      timeSpentOnDay: { '2026-08-31': HOUR * 1.5 },
+      timeSpent: HOUR * 1.5,
+    });
+  });
+
+  it('creates the day entry when none exists yet', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-30': HOUR } }];
+    await logTime('t1', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(patchFor('t1')).toEqual({
+      timeSpentOnDay: { '2026-08-30': HOUR, '2026-08-31': HOUR },
+      timeSpent: HOUR * 2,
+    });
+  });
+
+  it('handles a task that has never been tracked', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0 }];
+    await logTime('t1', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(patchFor('t1')).toEqual({ timeSpentOnDay: { '2026-08-31': HOUR }, timeSpent: HOUR });
+  });
+
+  it("overwrites the day's value in set mode", async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR * 3, timeSpentOnDay: { '2026-08-30': HOUR * 2, '2026-08-31': HOUR } }];
+    await logTime('t1', { date: '2026-08-31', durationMs: HOUR / 2, mode: 'set' });
+    expect(patchFor('t1')).toEqual({
+      timeSpentOnDay: { '2026-08-30': HOUR * 2, '2026-08-31': HOUR / 2 },
+      timeSpent: HOUR * 2.5,
+    });
+  });
+
+  it('removes the day entry when set to zero', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR * 3, timeSpentOnDay: { '2026-08-30': HOUR * 2, '2026-08-31': HOUR } }];
+    await logTime('t1', { date: '2026-08-31', durationMs: 0, mode: 'set' });
+    expect(patchFor('t1')).toEqual({
+      timeSpentOnDay: { '2026-08-30': HOUR * 2 },
+      timeSpent: HOUR * 2,
+    });
+  });
+
+  it('rolls the added time up to the parent task', async () => {
+    tasks = [
+      { id: 'sub', parentId: 'parent', timeSpent: 0, timeSpentOnDay: {} },
+      { id: 'parent', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-31': HOUR } },
+    ];
+    await logTime('sub', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(patchFor('parent')).toEqual({
+      timeSpentOnDay: { '2026-08-31': HOUR * 2 },
+      timeSpent: HOUR * 2,
+    });
+  });
+
+  it('rolls a set-mode reduction down on the parent', async () => {
+    tasks = [
+      { id: 'sub', parentId: 'parent', timeSpent: HOUR * 2, timeSpentOnDay: { '2026-08-31': HOUR * 2 } },
+      { id: 'parent', parentId: null, timeSpent: HOUR * 3, timeSpentOnDay: { '2026-08-31': HOUR * 3 } },
+    ];
+    await logTime('sub', { date: '2026-08-31', durationMs: HOUR, mode: 'set' });
+    expect(patchFor('parent')).toEqual({
+      timeSpentOnDay: { '2026-08-31': HOUR * 2 },
+      timeSpent: HOUR * 2,
+    });
+  });
+
+  it('never drives the parent below zero', async () => {
+    tasks = [
+      { id: 'sub', parentId: 'parent', timeSpent: HOUR * 2, timeSpentOnDay: { '2026-08-31': HOUR * 2 } },
+      { id: 'parent', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-31': HOUR } },
+    ];
+    await logTime('sub', { date: '2026-08-31', durationMs: 0, mode: 'set' });
+    expect(patchFor('parent')).toEqual({ timeSpentOnDay: {}, timeSpent: 0 });
+  });
+
+  it('leaves the parent alone for a top-level task', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    await logTime('t1', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(globalThis.PluginAPI.updateTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('errors on an unknown task instead of silently no-opping', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    const res = await logTime('nope', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('nope');
+    expect(globalThis.PluginAPI.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('returns the updated map and total', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    const res = await logTime('t1', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    expect(res.result).toEqual({
+      taskId: 't1',
+      date: '2026-08-31',
+      timeSpentOnDay: { '2026-08-31': HOUR },
+      timeSpent: HOUR,
+    });
+  });
+});

--- a/tests/unit/plugin/executeCommand.test.ts
+++ b/tests/unit/plugin/executeCommand.test.ts
@@ -8,6 +8,8 @@ declare global {
     addTask: ReturnType<typeof vi.fn>;
     updateTask: ReturnType<typeof vi.fn>;
     getTasks: ReturnType<typeof vi.fn>;
+    deleteTask?: ReturnType<typeof vi.fn>;
+    getArchivedTasks?: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -304,5 +306,68 @@ describe('executeCommand: logTimeEntries', () => {
     const res = await logEntries('nope', [{ date: '2026-08-31', durationMs: HOUR }]);
     expect(res.success).toBe(false);
     expect(globalThis.PluginAPI.updateTask).not.toHaveBeenCalled();
+  });
+});
+
+// PluginAPI exposes getArchivedTasks() for reading but nothing that deletes from
+// the archive, so deleting an archived task reported "Task not found" — misleading
+// for a task that plainly exists and is visible through get_tasks.
+describe('executeCommand: deleteTask on an archived task', () => {
+  const active = [{ id: 'live-1', title: 'Active task' }];
+  const archived = [{ id: 'arch-1', title: 'Archived task' }];
+
+  beforeEach(() => {
+    globalThis.PluginAPI = {
+      addTask: vi.fn(),
+      updateTask: vi.fn(),
+      getTasks: vi.fn(async () => active),
+      deleteTask: vi.fn().mockResolvedValue(undefined),
+      getArchivedTasks: vi.fn(async () => archived),
+    };
+  });
+
+  const del = (taskId: string) => executeCommand({ action: 'deleteTask', taskId });
+
+  it('says the task is archived rather than missing', async () => {
+    const res = await del('arch-1');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/archived/i);
+  });
+
+  it('points the user at where deletion is actually possible', async () => {
+    const res = await del('arch-1');
+    expect(res.error).toMatch(/Super Productivity/i);
+  });
+
+  it('does not attempt the delete it cannot perform', async () => {
+    await del('arch-1');
+    expect(globalThis.PluginAPI.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it('still reports a genuinely unknown id as not found', async () => {
+    const res = await del('no-such-task');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Task not found: no-such-task');
+    expect(res.error).not.toMatch(/archived/i);
+  });
+
+  it('still deletes an active task', async () => {
+    const res = await del('live-1');
+    expect(res.success).toBe(true);
+    expect(globalThis.PluginAPI.deleteTask).toHaveBeenCalledWith('live-1');
+  });
+
+  it('falls back to not-found when the archive cannot be read', async () => {
+    globalThis.PluginAPI.getArchivedTasks = vi.fn(async () => { throw new Error('unsupported'); });
+    const res = await del('arch-1');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Task not found: arch-1');
+  });
+
+  it('falls back to not-found on an SP build with no archive API', async () => {
+    delete globalThis.PluginAPI.getArchivedTasks;
+    const res = await del('arch-1');
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Task not found: arch-1');
   });
 });

--- a/tests/unit/plugin/executeCommand.test.ts
+++ b/tests/unit/plugin/executeCommand.test.ts
@@ -194,11 +194,115 @@ describe('executeCommand: logTime', () => {
   it('returns the updated map and total', async () => {
     tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
     const res = await logTime('t1', { date: '2026-08-31', durationMs: HOUR, mode: 'add' });
+    // The result reports every day it touched; the single-day form is a one-item list.
     expect(res.result).toEqual({
       taskId: 't1',
-      date: '2026-08-31',
+      dates: ['2026-08-31'],
       timeSpentOnDay: { '2026-08-31': HOUR },
       timeSpent: HOUR,
     });
+  });
+});
+
+// 007: multi-day logging. The caller sends durations per day, never a whole map,
+// so there is no agent-length window in which SP's timer can be clobbered.
+describe('executeCommand: logTimeEntries', () => {
+  const HOUR = 3_600_000;
+  let tasks: Record<string, unknown>[];
+
+  beforeEach(() => {
+    tasks = [];
+    globalThis.PluginAPI = {
+      addTask: vi.fn(),
+      updateTask: vi.fn().mockResolvedValue(undefined),
+      getTasks: vi.fn(async () => tasks),
+    };
+  });
+
+  const logEntries = (taskId: string, entries: unknown[], mode = 'add') =>
+    executeCommand({ action: 'logTimeEntries', taskId, data: { entries, mode } });
+
+  const patchFor = (taskId: string) =>
+    globalThis.PluginAPI.updateTask.mock.calls.find(([id]) => id === taskId)?.[1];
+
+  it('applies every day in one call', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    await logEntries('t1', [
+      { date: '2026-08-30', durationMs: HOUR * 2 },
+      { date: '2026-08-31', durationMs: HOUR },
+    ]);
+    expect(patchFor('t1')).toEqual({
+      timeSpentOnDay: { '2026-08-30': HOUR * 2, '2026-08-31': HOUR },
+      timeSpent: HOUR * 3,
+    });
+  });
+
+  it('writes the task once, not once per day', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    await logEntries('t1', [
+      { date: '2026-08-29', durationMs: HOUR },
+      { date: '2026-08-30', durationMs: HOUR },
+      { date: '2026-08-31', durationMs: HOUR },
+    ]);
+    expect(globalThis.PluginAPI.updateTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds onto days that already have time', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-30': HOUR } }];
+    await logEntries('t1', [{ date: '2026-08-30', durationMs: HOUR }]);
+    expect(patchFor('t1')).toEqual({ timeSpentOnDay: { '2026-08-30': HOUR * 2 }, timeSpent: HOUR * 2 });
+  });
+
+  it('overwrites each day in set mode', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR * 3, timeSpentOnDay: { '2026-08-30': HOUR * 3 } }];
+    await logEntries('t1', [{ date: '2026-08-30', durationMs: HOUR }], 'set');
+    expect(patchFor('t1')).toEqual({ timeSpentOnDay: { '2026-08-30': HOUR }, timeSpent: HOUR });
+  });
+
+  it('rolls every affected day up to the parent in a single update', async () => {
+    tasks = [
+      { id: 'sub', parentId: 'parent', timeSpent: 0, timeSpentOnDay: {} },
+      { id: 'parent', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-30': HOUR } },
+    ];
+    await logEntries('sub', [
+      { date: '2026-08-30', durationMs: HOUR },
+      { date: '2026-08-31', durationMs: HOUR * 2 },
+    ]);
+    expect(patchFor('parent')).toEqual({
+      timeSpentOnDay: { '2026-08-30': HOUR * 2, '2026-08-31': HOUR * 2 },
+      timeSpent: HOUR * 4,
+    });
+    expect(globalThis.PluginAPI.updateTask).toHaveBeenCalledTimes(2); // task + parent
+  });
+
+  it('reports the previous total when it disagreed with the worklog', async () => {
+    // A task imported from elsewhere: a total with no day attribution. SP would
+    // discard it at the next write, so the correction is surfaced, not hidden.
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR * 128, timeSpentOnDay: {} }];
+    const res = await logEntries('t1', [{ date: '2026-08-31', durationMs: HOUR }]);
+    expect((res.result as { previousTimeSpent?: number }).previousTimeSpent).toBe(HOUR * 128);
+    expect((res.result as { timeSpent: number }).timeSpent).toBe(HOUR);
+  });
+
+  it('omits previousTimeSpent when the total already matched the worklog', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: HOUR, timeSpentOnDay: { '2026-08-30': HOUR } }];
+    const res = await logEntries('t1', [{ date: '2026-08-31', durationMs: HOUR }]);
+    expect(res.result).not.toHaveProperty('previousTimeSpent');
+  });
+
+  it('returns every date it touched', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    const res = await logEntries('t1', [
+      { date: '2026-08-30', durationMs: HOUR },
+      { date: '2026-08-31', durationMs: HOUR },
+    ]);
+    expect((res.result as { dates: string[] }).dates).toEqual(['2026-08-30', '2026-08-31']);
+  });
+
+  it('errors on an unknown task without writing anything', async () => {
+    tasks = [{ id: 't1', parentId: null, timeSpent: 0, timeSpentOnDay: {} }];
+    const res = await logEntries('nope', [{ date: '2026-08-31', durationMs: HOUR }]);
+    expect(res.success).toBe(false);
+    expect(globalThis.PluginAPI.updateTask).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/plugin/version.test.ts
+++ b/tests/unit/plugin/version.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { executeCommand, PLUGIN_VERSION } from '../../../plugin/plugin.js';
+
+// check_connection reported 1.6.0 while running the 1.7.0 plugin, because the
+// version was a literal in the ping handler that the release bump didn't touch.
+// These pin it to the manifest so the drift is a red test, not a silent lie.
+const manifestVersion = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../../plugin/manifest.json', import.meta.url)), 'utf-8'),
+).version as string;
+
+describe('plugin version', () => {
+  beforeEach(() => {
+    globalThis.PluginAPI = { addTask: vi.fn(), updateTask: vi.fn(), getTasks: vi.fn() };
+  });
+
+  it('matches the manifest', () => {
+    expect(PLUGIN_VERSION).toBe(manifestVersion);
+  });
+
+  it('is what ping reports back to check_connection', async () => {
+    const res = await executeCommand({ action: 'ping' });
+    expect((res.result as { pluginVersion: string }).pluginVersion).toBe(manifestVersion);
+  });
+});

--- a/tests/unit/recording/instrument.test.ts
+++ b/tests/unit/recording/instrument.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { instrumentServer, extractOutcome } from '../../../src/recording/instrument.js';
+import type { ToolCallEntry, Recorder } from '../../../src/recording/recorder.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { okResult, errorResult } from '../../../src/tools/result.js';
+
+type ToolHandler = (...args: unknown[]) => Promise<unknown>;
+
+let recorded: ToolCallEntry[];
+let recorder: Recorder;
+let registered: Map<string, ToolHandler>;
+let resourceCalls: string[];
+let server: McpServer;
+
+beforeEach(() => {
+  recorded = [];
+  recorder = { record: (e) => { recorded.push(e); } };
+  registered = new Map();
+  resourceCalls = [];
+  server = {
+    registerTool: (name: string, _cfg: unknown, handler: ToolHandler) => { registered.set(name, handler); },
+    registerResource: (name: string) => { resourceCalls.push(name); },
+  } as unknown as McpServer;
+});
+
+/** Register a tool through the instrumented server and return its wrapped handler. */
+function register(name: string, handler: ToolHandler): ToolHandler {
+  instrumentServer(server, recorder).registerTool(name, {}, handler);
+  return registered.get(name)!;
+}
+
+describe('extractOutcome', () => {
+  it('parses the JSON payload out of a successful tool result', () => {
+    expect(extractOutcome(okResult({ taskId: 't1' }))).toEqual({ ok: true, result: { taskId: 't1' } });
+  });
+
+  it('lifts the message out of an error result', () => {
+    expect(extractOutcome(errorResult('Task not found: abc'))).toEqual({ ok: false, error: 'Task not found: abc' });
+  });
+
+  it('falls back to raw text when the payload is not JSON', () => {
+    const raw = { content: [{ type: 'text', text: 'plain words' }] };
+    expect(extractOutcome(raw)).toEqual({ ok: true, result: 'plain words' });
+  });
+
+  it('treats an unrecognised shape as a success carrying the whole value', () => {
+    expect(extractOutcome({ odd: true })).toEqual({ ok: true, result: { odd: true } });
+  });
+});
+
+describe('instrumentServer', () => {
+  it('records the tool name and a successful outcome', async () => {
+    await register('get_tasks', async () => okResult([{ id: '1' }]))({});
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({ tool: 'get_tasks', ok: true });
+    expect(recorded[0].result).toEqual([{ id: '1' }]);
+  });
+
+  it('records the arguments the client sent', async () => {
+    await register('log_time', async () => okResult({}))({ task_id: 't1', duration: '1h30m' });
+    expect(recorded[0].args).toEqual({ task_id: 't1', duration: '1h30m' });
+  });
+
+  it('records an empty object when the tool takes no arguments', async () => {
+    await register('stop_task', async () => okResult(null))();
+    expect(recorded[0].args).toEqual({});
+  });
+
+  it('records an error result as a failure with its message', async () => {
+    await register('update_task', async () => errorResult('Task not found: abc'))({});
+    expect(recorded[0]).toMatchObject({ ok: false, error: 'Task not found: abc' });
+  });
+
+  it('records a thrown handler as a failure and re-throws unchanged', async () => {
+    const boom = new Error('plugin exploded');
+    const handler = register('create_task', async () => { throw boom; });
+    await expect(handler({})).rejects.toBe(boom);
+    expect(recorded[0]).toMatchObject({ tool: 'create_task', ok: false, error: 'plugin exploded' });
+  });
+
+  it('returns the handler result unchanged (FR-005)', async () => {
+    const original = okResult({ deep: { value: 1 } });
+    const returned = await register('get_projects', async () => original)({});
+    expect(returned).toBe(original);
+  });
+
+  it('measures elapsed time', async () => {
+    await register('slow_tool', async () => {
+      await new Promise(r => setTimeout(r, 25));
+      return okResult({});
+    })({});
+    expect(recorded[0].ms).toBeGreaterThanOrEqual(10);
+  });
+
+  it('forwards every argument the SDK passes to the handler', async () => {
+    const handler = vi.fn(async () => okResult({}));
+    await register('get_tasks', handler)({ a: 1 }, { requestId: 'r1' });
+    expect(handler).toHaveBeenCalledWith({ a: 1 }, { requestId: 'r1' });
+  });
+
+  it('passes non-tool members through to the underlying server', () => {
+    instrumentServer(server, recorder).registerResource('tasks', {} as never, {} as never, (() => {}) as never);
+    expect(resourceCalls).toEqual(['tasks']);
+  });
+
+  it('does not fail the tool call when recording itself throws', async () => {
+    const angry: Recorder = { record: () => { throw new Error('disk full'); } };
+    instrumentServer(server, angry).registerTool('get_tags', {}, async () => okResult(['a']));
+    await expect(registered.get('get_tags')!({})).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/recording/recorder.test.ts
+++ b/tests/unit/recording/recorder.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createRecorder, LOG_FILENAME } from '../../../src/recording/recorder.js';
+import type { ResolvedDirs } from '../../../src/ipc/directories.js';
+
+let base: string;
+let dirs: ResolvedDirs;
+const logPath = () => join(base, LOG_FILENAME);
+const lines = () =>
+  readFileSync(logPath(), 'utf-8').split('\n').filter(l => l.trim() !== '');
+const entries = () => lines().map(l => JSON.parse(l));
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'sp-mcp-rec-'));
+  dirs = { base, commands: join(base, 'pc'), responses: join(base, 'pr') };
+});
+afterEach(() => rmSync(base, { recursive: true, force: true }));
+
+const entry = (over: Record<string, unknown> = {}) => ({
+  ts: 1_756_742_531_000, tool: 'get_tasks', args: {}, ms: 82, ok: true, result: { n: 1 }, ...over,
+});
+
+describe('createRecorder', () => {
+  it('appends one JSON line per call', () => {
+    const rec = createRecorder(dirs);
+    rec.record(entry());
+    rec.record(entry({ tool: 'log_time' }));
+    expect(entries().map(e => e.tool)).toEqual(['get_tasks', 'log_time']);
+  });
+
+  it('preserves every field of the entry', () => {
+    createRecorder(dirs).record(entry({ ms: 1904, ok: false, error: 'Task not found: abc' }));
+    expect(entries()[0]).toMatchObject({
+      ts: 1_756_742_531_000, tool: 'get_tasks', ms: 1904, ok: false, error: 'Task not found: abc',
+    });
+  });
+
+  it('creates the log 0600 so captured task content is not world-readable', () => {
+    createRecorder(dirs).record(entry());
+    expect(statSync(logPath()).mode & 0o777).toBe(0o600);
+  });
+
+  it('truncates an oversized result rather than mirroring the task database', () => {
+    createRecorder(dirs).record(entry({ result: { tasks: 'x'.repeat(20_000) } }));
+    expect(entries()[0].result._truncated).toBe(true);
+  });
+
+  it('truncates oversized args too', () => {
+    createRecorder(dirs).record(entry({ args: { notes: 'y'.repeat(20_000) } }));
+    expect(entries()[0].args._truncated).toBe(true);
+  });
+
+  it('enforces the cap, keeping the newest entries', () => {
+    const rec = createRecorder(dirs, { max: 5 });
+    for (let i = 0; i < 12; i++) rec.record(entry({ tool: `tool-${i}` }));
+    const tools = entries().map(e => e.tool);
+    expect(tools.length).toBeLessThanOrEqual(6);
+    expect(tools).toContain('tool-11');
+    expect(tools).not.toContain('tool-0');
+  });
+
+  it('counts entries already on disk from a previous session', () => {
+    createRecorder(dirs, { max: 5 }).record(entry({ tool: 'from-session-1' }));
+    const rec2 = createRecorder(dirs, { max: 5 });
+    for (let i = 0; i < 12; i++) rec2.record(entry({ tool: `tool-${i}` }));
+    expect(entries().length).toBeLessThanOrEqual(6);
+  });
+
+  it('never throws when the log cannot be written (FR-004)', () => {
+    const unwritable = { base: '/proc/nope/deep', commands: '/proc/nope/c', responses: '/proc/nope/r' };
+    const rec = createRecorder(unwritable);
+    expect(() => rec.record(entry())).not.toThrow();
+  });
+
+  it('does not create a log file merely by existing', () => {
+    createRecorder(dirs);
+    expect(existsSync(logPath())).toBe(false);
+  });
+});

--- a/tests/unit/recording/ring.test.ts
+++ b/tests/unit/recording/ring.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { needsPrune, prune } from '../../../src/recording/ring.js';
+
+describe('needsPrune', () => {
+  it('is false at the cap', () => {
+    expect(needsPrune(500, 500)).toBe(false);
+  });
+
+  it('is false while within the 20% slack', () => {
+    expect(needsPrune(599, 500)).toBe(false);
+  });
+
+  it('is true once the slack is exceeded', () => {
+    expect(needsPrune(601, 500)).toBe(true);
+  });
+
+  it('keeps rewrites rarer than 1 call in 100 (SC-003)', () => {
+    // The slack must span at least 100 appends, or the amortized prune
+    // stops being amortized and the append path pays for it.
+    const max = 500;
+    const firstPrune = 501;
+    let count = firstPrune;
+    while (!needsPrune(count, max)) count++;
+    expect(count - firstPrune).toBeGreaterThanOrEqual(100);
+  });
+});
+
+describe('prune', () => {
+  it('keeps the newest entries when over the cap', () => {
+    const lines = ['a', 'b', 'c', 'd', 'e'];
+    expect(prune(lines, 3)).toEqual(['c', 'd', 'e']);
+  });
+
+  it('drops the oldest first', () => {
+    expect(prune(['old', 'new'], 1)).toEqual(['new']);
+  });
+
+  it('leaves a list under the cap untouched', () => {
+    expect(prune(['a', 'b'], 5)).toEqual(['a', 'b']);
+  });
+
+  it('leaves a list exactly at the cap untouched', () => {
+    expect(prune(['a', 'b'], 2)).toEqual(['a', 'b']);
+  });
+
+  it('discards blank lines from a trailing newline', () => {
+    expect(prune(['a', '', 'b', ''], 5)).toEqual(['a', 'b']);
+  });
+});

--- a/tests/unit/recording/truncate.test.ts
+++ b/tests/unit/recording/truncate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { truncatePayload } from '../../../src/recording/truncate.js';
+
+describe('truncatePayload', () => {
+  it('passes a small payload through untouched', () => {
+    expect(truncatePayload({ a: 1 }, 8192)).toEqual({ a: 1 });
+  });
+
+  it('replaces an oversized payload with a marker', () => {
+    const big = { notes: 'x'.repeat(9000) };
+    const res = truncatePayload(big, 8192) as Record<string, unknown>;
+    expect(res._truncated).toBe(true);
+    expect(res.bytes).toBeGreaterThan(9000);
+  });
+
+  it('reports the real byte count so the pane can say what was elided', () => {
+    const big = { notes: 'y'.repeat(9000) };
+    const res = truncatePayload(big, 8192) as { bytes: number };
+    expect(res.bytes).toBe(Buffer.byteLength(JSON.stringify(big), 'utf8'));
+  });
+
+  it('includes a readable preview', () => {
+    const res = truncatePayload({ title: 'z'.repeat(9000) }, 8192) as { preview: string };
+    expect(res.preview.startsWith('{"title":"zzz')).toBe(true);
+    expect(res.preview.length).toBeLessThan(300);
+  });
+
+  it('keeps a payload that lands exactly on the cap', () => {
+    const value = { a: 'b' };
+    const exact = Buffer.byteLength(JSON.stringify(value), 'utf8');
+    expect(truncatePayload(value, exact)).toEqual(value);
+  });
+
+  it('measures bytes not characters, so multi-byte content is not undercounted', () => {
+    const value = { s: '€'.repeat(4000) }; // 3 bytes each
+    const res = truncatePayload(value, 8192) as { _truncated?: boolean };
+    expect(res._truncated).toBe(true);
+  });
+
+  it('survives an unserializable payload instead of throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const res = truncatePayload(circular, 8192) as Record<string, unknown>;
+    expect(res._truncated).toBe(true);
+    expect(res.preview).toContain('unserializable');
+  });
+
+  it('passes undefined through', () => {
+    expect(truncatePayload(undefined, 8192)).toBeUndefined();
+  });
+});

--- a/tests/unit/server-version.test.ts
+++ b/tests/unit/server-version.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { readPackageVersion } from '../../src/server.js';
+
+// The version was hardcoded in server.ts and silently went stale at the 1.7.0
+// release. This pins it to package.json so it can't drift again.
+describe('readPackageVersion', () => {
+  it('matches the version in package.json', () => {
+    const pkgPath = fileURLToPath(new URL('../../package.json', import.meta.url));
+    const expected = JSON.parse(readFileSync(pkgPath, 'utf-8')).version;
+    expect(readPackageVersion()).toBe(expected);
+  });
+
+  it('reports a real semver, not a placeholder', () => {
+    expect(readPackageVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/tests/unit/tools/duration.test.ts
+++ b/tests/unit/tools/duration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseDuration } from '../../../src/tools/duration.js';
+
+describe('parseDuration', () => {
+  it('parses a bare hours token', () => {
+    expect(parseDuration('2h')).toBe(7_200_000);
+  });
+
+  it('parses a bare minutes token', () => {
+    expect(parseDuration('45m')).toBe(2_700_000);
+  });
+
+  it('parses a bare seconds token', () => {
+    expect(parseDuration('90s')).toBe(90_000);
+  });
+
+  it('sums combined tokens', () => {
+    expect(parseDuration('1h30m')).toBe(5_400_000);
+  });
+
+  it('tolerates whitespace between tokens', () => {
+    expect(parseDuration('1h 30m 15s')).toBe(5_415_000);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseDuration('1H30M')).toBe(5_400_000);
+  });
+
+  it('accepts zero so set mode can clear a day', () => {
+    expect(parseDuration('0m')).toBe(0);
+  });
+
+  it('rejects an empty string', () => {
+    expect(parseDuration('')).toBeNull();
+  });
+
+  it('rejects a number with no unit', () => {
+    expect(parseDuration('90')).toBeNull();
+  });
+
+  it('rejects a trailing unitless number', () => {
+    expect(parseDuration('1h30')).toBeNull();
+  });
+
+  it('rejects a negative duration', () => {
+    expect(parseDuration('-1h')).toBeNull();
+  });
+
+  it('rejects fractional values', () => {
+    expect(parseDuration('1.5h')).toBeNull();
+  });
+
+  it('rejects an unsupported unit', () => {
+    expect(parseDuration('1d')).toBeNull();
+  });
+
+  it('rejects free text', () => {
+    expect(parseDuration('about an hour')).toBeNull();
+  });
+});

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -803,18 +803,18 @@ describe('log_time', () => {
   it('sends logTime with the parsed duration, defaulting to today and add mode', async () => {
     mockSend.mockResolvedValueOnce(mockResponse({ timeSpentOnDay: {}, timeSpent: 0 }));
     await callLogTime({ task_id: 'task-1', duration: '1h30m' });
-    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTime', {
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTimeEntries', {
       taskId: 'task-1',
-      data: { date: localDateStr(), durationMs: 5_400_000, mode: 'add' },
+      data: { entries: [{ date: localDateStr(), durationMs: 5_400_000 }], mode: 'add' },
     });
   });
 
   it('passes an explicit date and set mode through', async () => {
     mockSend.mockResolvedValueOnce(mockResponse({ timeSpentOnDay: {}, timeSpent: 0 }));
     await callLogTime({ task_id: 'task-1', duration: '45m', date: '2026-08-31', mode: 'set' });
-    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTime', {
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTimeEntries', {
       taskId: 'task-1',
-      data: { date: '2026-08-31', durationMs: 2_700_000, mode: 'set' },
+      data: { entries: [{ date: '2026-08-31', durationMs: 2_700_000 }], mode: 'set' },
     });
   });
 
@@ -859,5 +859,121 @@ describe('log_time', () => {
 
   it('rejects an unknown parameter (strict schema)', () => {
     expect(logTimeSchema.safeParse({ task_id: 'task-1', duration: '1h', durration: '2h' }).success).toBe(false);
+  });
+});
+
+// 007: the per-day map is the only writable representation of time spent.
+describe('log_time multi-day', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  type ToolResult = { isError?: boolean; content: { text: string }[] };
+  const callLogTime = (args: Record<string, unknown>) =>
+    toolHandlers.get('log_time')!(args) as Promise<ToolResult>;
+  const errorOf = (res: ToolResult) => JSON.parse(res.content[0].text).error as string;
+
+  it('normalises a single-day call into one entry', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({}));
+    await callLogTime({ task_id: 't1', duration: '1h30m', date: '2026-08-31' });
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTimeEntries', {
+      taskId: 't1',
+      data: { entries: [{ date: '2026-08-31', durationMs: 5_400_000 }], mode: 'add' },
+    });
+  });
+
+  it('sends every entry of a multi-day call', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({}));
+    await callLogTime({
+      task_id: 't1',
+      entries: [{ date: '2026-08-30', duration: '2h' }, { date: '2026-08-31', duration: '45m' }],
+    });
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTimeEntries', {
+      taskId: 't1',
+      data: {
+        entries: [
+          { date: '2026-08-30', durationMs: 7_200_000 },
+          { date: '2026-08-31', durationMs: 2_700_000 },
+        ],
+        mode: 'add',
+      },
+    });
+  });
+
+  it('applies mode to every entry', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({}));
+    await callLogTime({ task_id: 't1', mode: 'set', entries: [{ date: '2026-08-30', duration: '2h' }] });
+    expect(mockSend.mock.calls[0][2]).toMatchObject({ data: expect.objectContaining({ mode: 'set' }) });
+  });
+
+  it('rejects duration and entries together', async () => {
+    const res = await callLogTime({ task_id: 't1', duration: '1h', entries: [{ date: '2026-08-30', duration: '2h' }] });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects a call with neither duration nor entries', async () => {
+    const res = await callLogTime({ task_id: 't1' });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty entries array', async () => {
+    const res = await callLogTime({ task_id: 't1', entries: [] });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate dates rather than letting one silently win', async () => {
+    const res = await callLogTime({
+      task_id: 't1',
+      entries: [{ date: '2026-08-30', duration: '2h' }, { date: '2026-08-30', duration: '1h' }],
+    });
+    expect(res.isError).toBe(true);
+    expect(errorOf(res)).toMatch(/duplicate/i);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('fails the whole call when one entry has a bad duration, writing nothing', async () => {
+    const res = await callLogTime({
+      task_id: 't1',
+      entries: [{ date: '2026-08-30', duration: '2h' }, { date: '2026-08-31', duration: 'ages' }],
+    });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('fails the whole call when one entry has a bad date', async () => {
+    const res = await callLogTime({
+      task_id: 't1',
+      entries: [{ date: '2026-08-30', duration: '2h' }, { date: '30-08-2026', duration: '1h' }],
+    });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('caps entries at 100 like the other bulk tools', () => {
+    const many = Array.from({ length: 101 }, (_, i) => ({ date: `2026-01-${i}`, duration: '1h' }));
+    expect(logTimeSchema.safeParse({ task_id: 't1', entries: many }).success).toBe(false);
+  });
+
+  it('requires a date on every entry — a list has no "default to today"', () => {
+    expect(logTimeSchema.safeParse({ task_id: 't1', entries: [{ duration: '1h' }] }).success).toBe(false);
+  });
+});
+
+describe('time_spent removal (007)', () => {
+  it('update_task no longer accepts time_spent', () => {
+    expect(updateTaskSchema.safeParse({ task_id: 't1', time_spent: 5000 }).success).toBe(false);
+  });
+
+  it('update_task still accepts time_estimate — SP stores that field directly', () => {
+    expect(updateTaskSchema.safeParse({ task_id: 't1', time_estimate: 5000 }).success).toBe(true);
+  });
+
+  it('bulk_update_tasks no longer accepts time_spent', () => {
+    expect(bulkUpdateTasksSchema.safeParse({ updates: [{ task_id: 't1', time_spent: 5000 }] }).success).toBe(false);
+  });
+
+  it('bulk_update_tasks still accepts time_estimate', () => {
+    expect(bulkUpdateTasksSchema.safeParse({ updates: [{ task_id: 't1', time_estimate: 5000 }] }).success).toBe(true);
   });
 });

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -12,6 +12,7 @@ import {
   updateTaskSchema,
   createTaskWithSubtasksSchema,
   bulkUpdateTasksSchema,
+  logTimeSchema,
   registerTaskTools,
 } from '../../../src/tools/tasks.js';
 import type { ResolvedDirs } from '../../../src/ipc/directories.js';
@@ -786,5 +787,77 @@ describe('task tool logic', () => {
       expect(res.success).toBe(false);
       expect(res.error).toBe('Failed to get repeat configs');
     });
+  });
+});
+
+// log_time drives the real registered handler (like the deadline_day tests above),
+// since the point is the mapping from short syntax + defaults onto the logTime command.
+describe('log_time', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  type ToolResult = { isError?: boolean; content: { text: string }[] };
+  const callLogTime = (args: Record<string, unknown>) =>
+    toolHandlers.get('log_time')!(args) as Promise<ToolResult>;
+  const errorOf = (res: ToolResult) => JSON.parse(res.content[0].text).error as string;
+
+  it('sends logTime with the parsed duration, defaulting to today and add mode', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({ timeSpentOnDay: {}, timeSpent: 0 }));
+    await callLogTime({ task_id: 'task-1', duration: '1h30m' });
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTime', {
+      taskId: 'task-1',
+      data: { date: localDateStr(), durationMs: 5_400_000, mode: 'add' },
+    });
+  });
+
+  it('passes an explicit date and set mode through', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({ timeSpentOnDay: {}, timeSpent: 0 }));
+    await callLogTime({ task_id: 'task-1', duration: '45m', date: '2026-08-31', mode: 'set' });
+    expect(mockSend).toHaveBeenCalledWith(dirs, 'logTime', {
+      taskId: 'task-1',
+      data: { date: '2026-08-31', durationMs: 2_700_000, mode: 'set' },
+    });
+  });
+
+  it('rejects an unparseable duration without sending a command', async () => {
+    const res = await callLogTime({ task_id: 'task-1', duration: 'about an hour' });
+    expect(res.isError).toBe(true);
+    expect(errorOf(res)).toMatch(/duration/i);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed date without sending a command', async () => {
+    const res = await callLogTime({ task_id: 'task-1', duration: '1h', date: '31-08-2026' });
+    expect(res.isError).toBe(true);
+    expect(errorOf(res)).toMatch(/date/i);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects a blank task_id without sending a command', async () => {
+    const res = await callLogTime({ task_id: '  ', duration: '1h' });
+    expect(res.isError).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the plugin error when the task does not exist', async () => {
+    mockSend.mockResolvedValueOnce({ success: false, error: 'Task not found: nope', timestamp: Date.now() });
+    const res = await callLogTime({ task_id: 'nope', duration: '1h' });
+    expect(res.isError).toBe(true);
+    expect(errorOf(res)).toBe('Task not found: nope');
+  });
+
+  it('returns the updated per-day map from the plugin', async () => {
+    mockSend.mockResolvedValueOnce(mockResponse({
+      taskId: 'task-1',
+      date: '2026-08-31',
+      timeSpentOnDay: { '2026-08-31': 5_400_000 },
+      timeSpent: 5_400_000,
+    }));
+    const res = await callLogTime({ task_id: 'task-1', duration: '1h30m', date: '2026-08-31' });
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text).timeSpentOnDay).toEqual({ '2026-08-31': 5_400_000 });
+  });
+
+  it('rejects an unknown parameter (strict schema)', () => {
+    expect(logTimeSchema.safeParse({ task_id: 'task-1', duration: '1h', durration: '2h' }).success).toBe(false);
   });
 });


### PR DESCRIPTION
NGL I meant to open this against my own repo first. But since we're here now, might as well keep it open and have it looked at by the original author :).

My motivation for this was adding a `log_time` action so I can backfill some work logging using Claude Code. On the way there, I mixed in a dashboard pane and some bugfixes (the dashboard could be split off).

# Changes
- Added the `log_time` action. Allows adding or setting the time spent to one or more days for a certain task.
- Also removed `time_spent` from `update_task` and `bulk_update_tasks`.  SP derives `timeSpent` from `timeSpentOnDay` on every path, so writing a bare total produced tasks SP's own model can't represent and silently discards. Reads are unaffected, `timeSpentOnDay` is now documented and included in the resource summary.
- Added a pane tool call recording. The recorder is a ring buffer of max. 500 entries. Records tool name, parameters and results (capped at 8KB).
- Fixed `check_connection` reporting a hardcoded version. Now pinned to the manifest.
- `delete_task` said `Task not found` for archived tasks. They exist and are readable; SP's plugin API just has no way to delete them. The error now says so.
-  `server.ts` hardcoded its version, stale since 1.7.0. Reads `package.json`.
- Added a Makefile for ease of compilation and adding the MCP server to Claude Code as a target (depends on compilation).
- Added 100 new tests.

Note: This PR does change the shape of the API, if merged, there's a good case for bumping the major version.