### PR TITLE
fix(macOS): resolve native and sandbox IPC paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Reads resources for context, creates subtasks in batch, starts the timer, bulk-c
 
 → [More use cases](docs/use-cases.md)
 
+## Local deployment documentation
+
+For a pinned source-based macOS deployment, see:
+
+- [macOS setup and operations](docs/macos-setup.md)
+- [Troubleshooting](docs/troubleshooting.md)
+
 ## Installation
 
 ### 1. Install the SP Plugin

--- a/config/codex-mcp.example.toml
+++ b/config/codex-mcp.example.toml
@@ -1,0 +1,15 @@
+# Example only. Copy the relevant section to ~/.codex/config.toml and replace
+# every placeholder with an absolute path on the target machine.
+
+[mcp_servers.super_productivity]
+command = "/absolute/path/to/node"
+args = ["/absolute/path/to/Super-Productivity-MCP/dist/index.js"]
+
+# Allow read-only inspection without a write prompt. Keep task mutations
+# approval-gated.
+default_tools_approval_mode = "writes"
+startup_timeout_sec = 120
+
+[mcp_servers.super_productivity.env]
+# The server and the Super Productivity plugin must use the same directory.
+SP_MCP_DATA_DIR = "/absolute/path/to/super-productivity-mcp"

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -1,0 +1,162 @@
+# macOS setup and operations
+
+This runbook describes a pinned, source-based macOS deployment of the Super
+Productivity MCP bridge. It covers the two components that must be running
+together:
+
+1. the MCP server used by Codex or another MCP client; and
+2. the Super Productivity plugin that receives commands through file-based
+   IPC.
+
+The server and plugin must use the same MCP data directory. If they use
+different directories, the server can be running while Super Productivity
+appears unresponsive.
+
+## Ownership of files and state
+
+| Item | Location | Versioned? |
+| --- | --- | --- |
+| MCP server and plugin source | this repository (`src/` and `plugin/`) | Yes |
+| Generated server and plugin bundle | `dist/` | Generated; do not edit by hand |
+| Codex registration | `~/.codex/config.toml` | No; keep an example in `config/` |
+| Super Productivity application data and task database | `~/Library/Application Support/superProductivity/` | No |
+| MCP IPC directory | `~/Library/Application Support/super-productivity-mcp/` | No |
+| App Store sandbox IPC fallback | `~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp/` | No |
+
+Do not commit task databases, IPC command/response files, local logs, tokens,
+or a machine-specific Codex configuration. The repository should document how
+to recreate the setup, not copy the live task state.
+
+## Current local deployment
+
+The working deployment uses:
+
+- the checked-out `dist/index.js` rather than an `npx` download;
+- the rebuilt `dist/plugin.zip` uploaded to Super Productivity;
+- an explicit `SP_MCP_DATA_DIR` pointing at the native macOS Application
+  Support directory; and
+- Codex write approval for mutating MCP tools.
+
+The corresponding configuration shape is shown in
+[`config/codex-mcp.example.toml`](../config/codex-mcp.example.toml). The
+actual local configuration must use absolute paths for the current checkout.
+
+## Build and install from source
+
+From the repository root:
+
+```bash
+npm ci
+npm run typecheck
+npm test
+npm run lint
+npm run build
+```
+
+`npm run build` compiles the MCP server and creates `dist/plugin.zip`.
+
+Then install the plugin:
+
+1. Open Super Productivity.
+2. Go to **Settings → Plugins → Upload Plugin**.
+3. Select `dist/plugin.zip`.
+4. Enable the plugin.
+5. Accept the one-time Node execution permission.
+6. Restart Super Productivity if the plugin does not respond immediately.
+
+The server and plugin should be kept on the same version. After changing
+either side, rebuild and reinstall the plugin before testing again.
+
+## Codex configuration
+
+The live file is `~/.codex/config.toml`. A source-based entry has this shape:
+
+```toml
+[mcp_servers.super_productivity]
+command = "/absolute/path/to/node"
+args = ["/absolute/path/to/Super-Productivity-MCP/dist/index.js"]
+default_tools_approval_mode = "writes"
+startup_timeout_sec = 120
+
+[mcp_servers.super_productivity.env]
+SP_MCP_DATA_DIR = "/absolute/path/to/Library/Application Support/super-productivity-mcp"
+```
+
+A local deployment may use Homebrew Node and a repository checkout selected by
+the user. Keep those machine-specific values in `~/.codex/config.toml`; use the
+redacted template in this repository when configuring another machine. Do not
+commit personal home-directory paths or local task-system details to this
+public repository.
+
+Check registration with:
+
+```bash
+codex mcp list
+```
+
+## Verification checklist
+
+Run these checks in order:
+
+1. Confirm that Super Productivity is open and the MCP plugin is enabled.
+2. Ask Codex to run `check_connection`.
+3. If the connection fails, ask Codex for `debug_directories`.
+4. Confirm that the server and plugin report the same `SP_MCP_DATA_DIR`.
+5. Read the newest IPC response file:
+
+   ```bash
+   ls -lt ~/Library/Application\ Support/super-productivity-mcp/plugin_responses/ | head -5
+   ```
+
+6. Perform a harmless read-only task query before testing a write.
+7. Test a write only after reviewing the proposed change and approving it.
+
+## Diagnosing the macOS path problem
+
+The plugin checks both of these locations:
+
+```text
+~/Library/Application Support/super-productivity-mcp
+~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp
+```
+
+To see which location is active:
+
+```bash
+ls -lt ~/Library/Application\ Support/super-productivity-mcp/plugin_responses/ 2>/dev/null | head -5
+ls -lt ~/Library/Containers/com.superproductivity.app/Data/Library/Application\ Support/super-productivity-mcp/plugin_responses/ 2>/dev/null | head -5
+```
+
+If the plugin writes to the sandbox location, set `SP_MCP_DATA_DIR` to that
+absolute path in the MCP client configuration. Do not guess based only on the
+path displayed by the application; verify which directory receives recent
+response files.
+
+## If Super Productivity starts and then stops responding
+
+Use this recovery sequence:
+
+1. Toggle the MCP plugin off and on in **Settings → Plugins**.
+2. Confirm that the Node execution permission was accepted.
+3. Confirm that the installed plugin and the running server have the same
+   version.
+4. Run `check_connection` and `debug_directories` again.
+5. Confirm that `SP_MCP_DATA_DIR` is explicit and writable.
+6. Restart both Super Productivity and the Codex session.
+
+The general troubleshooting guide contains the version-specific SP startup
+notes: [`docs/troubleshooting.md`](troubleshooting.md).
+
+## Security and maintenance
+
+The plugin uses privileged Node execution and file-based IPC. Treat plugin
+updates as executable code: inspect the diff, rebuild from the intended commit,
+and upload the resulting bundle. Keep Codex's default MCP write mode at
+`"writes"` so reads can be used for inspection while task mutations remain an
+approval checkpoint.
+
+The current macOS path fix is maintained in the fork and proposed upstream in
+[Super-Productivity-MCP PR #111](https://github.com/b0x42/Super-Productivity-MCP/pull/111).
+Do not replace the pinned local deployment with an upstream or `npx` version
+until the upstream change has been reviewed and the exact tested commit is
+known.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,17 +12,17 @@ If the connection check fails after a fresh install or reboot, toggle the plugin
 4. If paths differ between server and plugin, set `SP_MCP_DATA_DIR` (see below)
 5. Restart both SP and your MCP client
 
-## Mac App Store — Sandbox Path Mismatch
+## macOS — Sandbox Path Mismatch
 
-When SP is installed from the Mac App Store, it runs in a sandbox. The MCP server and the SP plugin resolve the shared data directory independently and can disagree on the path:
+Super Productivity can use two different shared-data locations on macOS. Native `.app` installs use the normal Application Support path; Mac App Store installs use the container path. The plugin prefers the native path and falls back to the container path, but the MCP server and plugin must ultimately use the same directory:
 
-- Sandbox: `~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp`
-- Non-sandbox: `~/.local/share/super-productivity-mcp`
+- Native `.app`: `~/Library/Application Support/super-productivity-mcp`
+- Mac App Store sandbox: `~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp`
 
 **Diagnose** — check which directory the plugin is actually writing to:
 
 ```bash
-ls -lt ~/.local/share/super-productivity-mcp/plugin_responses/ | head -5
+ls -lt ~/Library/Application\ Support/super-productivity-mcp/plugin_responses/ | head -5
 ls -lt ~/Library/Containers/com.superproductivity.app/Data/Library/Application\ Support/super-productivity-mcp/plugin_responses/ | head -5
 ```
 
@@ -58,7 +58,7 @@ Common values:
 
 | Scenario | Path |
 |----------|------|
-| macOS non-sandbox | `~/.local/share/super-productivity-mcp` |
+| macOS native `.app` | `~/Library/Application Support/super-productivity-mcp` |
 | macOS App Store sandbox | `~/Library/Containers/com.superproductivity.app/Data/Library/Application Support/super-productivity-mcp` |
 | Linux (standard) | `~/.local/share/super-productivity-mcp` |
 | Linux (Snap) | `~/snap/superproductivity/current/.local/share/super-productivity-mcp` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-productivity-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "super-productivity-mcp",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-productivity-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MCP server for Super Productivity — manage tasks, projects, and tags via AI assistants",
   "main": "dist/index.js",
   "bin": {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "super-productivity-mcp",
   "name": "SP MCP Server",
   "description": "MCP server bridge for AI assistant integration with Super Productivity",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "manifestVersion": 1,
   "minSupVersion": "14.0.0",
   "permissions": [

--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -90,9 +90,12 @@ async function setupDirectories() {
       const TMP_DATA_DIR = path.join(TMP_ROOT, APP);
       let candidates;
       if (os.platform() === 'darwin') {
+        // Native macOS builds use ~/Library/Application Support. Keep the
+        // Mac App Store container as a fallback, but do not let a stale Store
+        // directory shadow a working native installation.
         candidates = [
-          path.join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP),
-          path.join(home, 'Library', 'Application Support', APP)
+          path.join(home, 'Library', 'Application Support', APP),
+          path.join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP)
         ];
       } else if (os.platform() === 'win32') {
         const appData = (typeof process !== 'undefined' && process.env && process.env.APPDATA) || path.join(home, 'AppData', 'Roaming');
@@ -596,7 +599,7 @@ async function executeCommand(command) {
         break;
       }
       case 'ping':
-        result = { pong: true, pluginVersion: '1.6.0', protocolVersion: PROTOCOL_VERSION };
+        result = { pong: true, pluginVersion: '1.6.1', protocolVersion: PROTOCOL_VERSION };
         break;
       default:
         return { success: false, error: `Unknown command action: ${command.action}`, timestamp: Date.now() };

--- a/src/ipc/directories.ts
+++ b/src/ipc/directories.ts
@@ -6,13 +6,19 @@ import type { McpConfig } from './types.js';
 const APP_NAME = 'super-productivity-mcp';
 const TMP_ROOT = '/tmp';
 
-export function getCandidatePaths(): string[] {
-  const home = homedir();
-  switch (platform()) {
+export function getCandidatePaths(
+  platformName: NodeJS.Platform = platform(),
+  home = homedir(),
+): string[] {
+  switch (platformName) {
     case 'darwin':
+      // Native macOS builds use ~/Library/Application Support. The container
+      // path is retained as a fallback for Mac App Store installations. The
+      // native path must come first so a stale Store container cannot shadow a
+      // working native installation.
       return [
-        join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP_NAME),
         join(home, 'Library', 'Application Support', APP_NAME),
+        join(home, 'Library', 'Containers', 'com.super-productivity.app', 'Data', 'Library', 'Application Support', APP_NAME),
       ];
     case 'win32':
       return [join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), APP_NAME)];
@@ -51,40 +57,47 @@ function isTmpDataDir(dir: string): boolean {
   return dir === TMP_ROOT || dir.startsWith(`${TMP_ROOT}/`);
 }
 
-export function resolveDataDir(): string {
+function publishConfig(dataDir: string, candidatePaths: string[]): void {
+  // The plugin cannot inherit the MCP client's environment. Publish the
+  // selected directory at every writable canonical location so native and
+  // App Store sandbox installations can discover the same explicit override.
+  for (const configRoot of candidatePaths) {
+    try {
+      ensureWritableDir(configRoot);
+      const configPath = join(configRoot, 'mcp_config.json');
+      const config: McpConfig = { dataDir };
+      writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+    } catch {
+      // The configured data directory itself remains usable even if one
+      // discovery marker cannot be written; continue with the next candidate.
+    }
+  }
+}
+
+export function resolveDataDir(candidatePaths = getCandidatePaths()): string {
   const envOverride = process.env.SP_MCP_DATA_DIR;
   if (envOverride) {
     ensureIpcDirs(envOverride);
-    // Write mcp_config.json to standard location so plugin can find it
-    const standardPaths = getCandidatePaths();
-    for (const p of standardPaths) {
-      try {
-        ensureWritableDir(p);
-        const configPath = join(p, 'mcp_config.json');
-        const config: McpConfig = { dataDir: envOverride };
-        writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
-        break;
-      } catch { /* try next */ }
-    }
+    publishConfig(envOverride, candidatePaths);
     return envOverride;
   }
 
   // Check for mcp_config.json in candidate paths
-  for (const p of getCandidatePaths()) {
-    const configPath = join(p, 'mcp_config.json');
-    if (existsSync(configPath)) {
-      try {
+  for (const p of candidatePaths) {
+    try {
+      const configPath = join(p, 'mcp_config.json');
+      if (existsSync(configPath)) {
         const config: McpConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
         if (config.dataDir && existsSync(config.dataDir) && !isTmpDataDir(config.dataDir)) {
           ensureIpcDirs(config.dataDir);
           return config.dataDir;
         }
-      } catch { /* ignore invalid config */ }
-    }
+      }
+    } catch { /* ignore inaccessible or invalid config */ }
   }
 
   // Probe for first writable path
-  for (const p of getCandidatePaths()) {
+  for (const p of candidatePaths) {
     try {
       ensureIpcDirs(p);
       return p;
@@ -100,8 +113,8 @@ export interface ResolvedDirs {
   responses: string;
 }
 
-export function resolveDirectories(): ResolvedDirs {
-  const base = resolveDataDir();
+export function resolveDirectories(candidatePaths = getCandidatePaths()): ResolvedDirs {
+  const base = resolveDataDir(candidatePaths);
   const commands = join(base, 'plugin_commands');
   const responses = join(base, 'plugin_responses');
   ensureWritableDir(commands);

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ export function createServer(): { server: McpServer; dirs: ResolvedDirs } {
 
   const server = new McpServer({
     name: 'super-productivity',
-    version: '1.6.0',
+    version: '1.6.1',
   });
 
   registerTaskTools(server, dirs);

--- a/tests/unit/directories.test.ts
+++ b/tests/unit/directories.test.ts
@@ -21,7 +21,7 @@ describe('directories', () => {
     process.env.SP_MCP_DATA_DIR = customDir;
 
     const { resolveDataDir } = await import('../../src/ipc/directories.js');
-    const result = resolveDataDir();
+    const result = resolveDataDir([]);
     expect(result).toBe(customDir);
     expect(existsSync(customDir)).toBe(true);
   });
@@ -31,12 +31,52 @@ describe('directories', () => {
     process.env.SP_MCP_DATA_DIR = customDir;
 
     const { resolveDirectories } = await import('../../src/ipc/directories.js');
-    const dirs = resolveDirectories();
+    const dirs = resolveDirectories([]);
     expect(dirs.base).toBe(customDir);
     expect(dirs.commands).toBe(join(customDir, 'plugin_commands'));
     expect(dirs.responses).toBe(join(customDir, 'plugin_responses'));
     expect(existsSync(dirs.commands)).toBe(true);
     expect(existsSync(dirs.responses)).toBe(true);
+  });
+
+  it('prefers the native macOS data directory before the App Store fallback', async () => {
+    const { getCandidatePaths } = await import('../../src/ipc/directories.js');
+    const paths = getCandidatePaths('darwin', '/Users/test');
+
+    expect(paths).toEqual([
+      '/Users/test/Library/Application Support/super-productivity-mcp',
+      '/Users/test/Library/Containers/com.super-productivity.app/Data/Library/Application Support/super-productivity-mcp',
+    ]);
+  });
+
+  it('publishes an explicit override at the canonical discovery path', async () => {
+    const customDir = join(testDir, 'custom');
+    const canonicalDir = join(testDir, 'canonical');
+    process.env.SP_MCP_DATA_DIR = customDir;
+
+    const { resolveDataDir } = await import('../../src/ipc/directories.js');
+    const result = resolveDataDir([canonicalDir]);
+
+    expect(result).toBe(customDir);
+    expect(JSON.parse(readFileSync(join(canonicalDir, 'mcp_config.json'), 'utf8'))).toEqual({
+      dataDir: customDir,
+    });
+  });
+
+  it('publishes an explicit override to native and sandbox discovery paths', async () => {
+    const customDir = join(testDir, 'custom');
+    const nativeDir = join(testDir, 'native');
+    const sandboxDir = join(testDir, 'sandbox');
+    process.env.SP_MCP_DATA_DIR = customDir;
+
+    const { resolveDataDir } = await import('../../src/ipc/directories.js');
+    expect(resolveDataDir([nativeDir, sandboxDir])).toBe(customDir);
+
+    for (const candidate of [nativeDir, sandboxDir]) {
+      expect(JSON.parse(readFileSync(join(candidate, 'mcp_config.json'), 'utf8'))).toEqual({
+        dataDir: customDir,
+      });
+    }
   });
 
   it('linux candidates include /tmp fallback', async () => {

--- a/tests/unit/plugin-source.test.ts
+++ b/tests/unit/plugin-source.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const pluginSource = readFileSync(new URL('../../plugin/plugin.js', import.meta.url), 'utf8');
+
+describe('plugin startup path selection', () => {
+  it('prefers the native macOS directory before the App Store container', () => {
+    const nativePath = pluginSource.indexOf("path.join(home, 'Library', 'Application Support', APP)");
+    const sandboxPath = pluginSource.indexOf("path.join(home, 'Library', 'Containers', 'com.super-productivity.app'");
+
+    expect(nativePath).toBeGreaterThanOrEqual(0);
+    expect(sandboxPath).toBeGreaterThan(nativePath);
+  });
+
+  it('defers node initialization until the bridge is ready', () => {
+    expect(pluginSource).toContain('PluginAPI.onReady(init)');
+  });
+});


### PR DESCRIPTION
## Summary

- Prefer the native macOS Application Support directory before the Mac App Store container fallback.
- Publish an explicit `SP_MCP_DATA_DIR` override to every writable macOS discovery candidate so native and sandbox installs resolve the same IPC directory.
- Keep the existing `PluginAPI.onReady(init)` startup behavior and non-macOS candidate ordering.
- Bump the MCP/plugin version to `1.6.1` and add regression coverage for macOS path selection and source packaging.
- Clarify the macOS troubleshooting paths.

## Reproduction

On macOS with Super Productivity `18.21.2` installed as a native `.app`, the MCP plugin could be enabled while the UI remained responsive, but MCP commands timed out. The machine also had a stale Mac App Store container directory containing the older discovery marker.

The MCP server and plugin independently selected the first writable/discoverable candidate. The container candidate was checked before the native Application Support path, so the two processes could use different IPC directories. This was especially confusing because the plugin appeared enabled and Super Productivity itself continued running.

## Fix

The native path is now the first macOS candidate in both the TypeScript server and the packaged plugin. The container path remains available as a fallback. When `SP_MCP_DATA_DIR` is set, the server writes the same discovery marker to every writable candidate, allowing either macOS installation layout to find the configured directory.

This is complementary to the Super Productivity readiness fix in https://github.com/super-productivity/super-productivity/pull/7578, which closed https://github.com/super-productivity/super-productivity/issues/7326. The MCP plugin already uses `PluginAPI.onReady(init)`; this change fixes the remaining macOS path-selection problem.

## Validation

- `npm test`: 14 test files, 194 tests passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed; produces `dist/index.js` and `dist/plugin.zip`
- Live macOS smoke test: MCP server `1.6.1` reported `connected`; plugin reported `1.6.1`; `get_tags` and `create_tag` succeeded
- Native and container discovery markers were verified to point to the same configured directory
- No Super Productivity tasks were modified during testing

## Compatibility

Linux and Windows candidate ordering is unchanged. The Mac App Store container path remains supported, while native `.app` installations now resolve their normal Application Support location first.
